### PR TITLE
Add finalize(cursor) hook to state processor protocol

### DIFF
--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -581,6 +581,11 @@ class PGJsonbStorage(ConflictResolvingStorage, BaseStorage):
                 blob_threshold=self._blob_threshold,
             )
 
+            # ── State processor finalize hook ────────────────────
+            for proc in self._state_processors:
+                if hasattr(proc, "finalize"):
+                    proc.finalize(cur)
+
         return self._resolved or None
 
     def tpc_finish(self, transaction, f=None):
@@ -1289,6 +1294,11 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
                 s3_client=self._s3_client,
                 blob_threshold=self._blob_threshold,
             )
+
+            # ── State processor finalize hook ────────────────────
+            for proc in self._main._state_processors:
+                if hasattr(proc, "finalize"):
+                    proc.finalize(cur)
 
         return self._resolved or None
 


### PR DESCRIPTION
## Summary

- Add optional `finalize(cursor)` hook to the state processor duck-type protocol
- Called during `tpc_vote()` after `_batch_write_objects()` / `_batch_write_blobs()`, using the same cursor (same PG transaction)
- Backward compatible: processors without `finalize()` are silently skipped via `hasattr` check
- Enables downstream consumers (e.g. plone-pgcatalog) to execute additional SQL atomically within the commit transaction

### Use case

plone-pgcatalog needs to apply partial JSONB merges (`idx || patch`) for lightweight reindex operations (e.g. `reindexObjectSecurity`) without full ZODB serialization. The `finalize(cursor)` hook provides the extension point.

See: [bluedynamics/plone-pgcatalog#5](https://github.com/bluedynamics/plone-pgcatalog/issues/5)

### Changes

**storage.py:**
- `PGJsonbStorage._vote()` — call `finalize(cur)` on processors after batch writes
- `PGJsonbStorageInstance.tpc_vote()` — same pattern using `self._main._state_processors`

**test_state_processor.py:**
- 5 new tests: called during tpc_vote, called each commit, can execute SQL, skips processors without finalize, not called on abort

## Test plan

- [x] All 267 existing tests pass
- [x] 5 new finalize hook tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)