### PR TITLE
fix: handle PermissionError in _stage_blob hard-link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.6.1
+
+- Fix `_stage_blob` `PermissionError` when hard-linking blobs owned by
+  another user (e.g. Docker's uid 500). `fs.protected_hardlinks` blocks
+  the link even on the same filesystem. Now falls back to using the
+  source path directly.
+
 ## 1.6.0
 
 - Support incremental parallel imports with watermark-based resume.

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -2482,8 +2482,13 @@ def _stage_blob(src, temp_dir):
     fd, tmp = tempfile.mkstemp(suffix=".blob", dir=temp_dir)
     os.close(fd)
     os.unlink(tmp)  # remove empty placeholder
-    os.link(src, tmp)
-    return tmp, True
+    try:
+        os.link(src, tmp)
+        return tmp, True
+    except OSError:
+        # Hard-link failed (e.g. fs.protected_hardlinks blocks linking
+        # to files owned by another user). Use source directly.
+        return src, False
 
 
 def _table_exists(cur, table_name):


### PR DESCRIPTION
## Summary

- Catch `OSError` when `os.link()` fails due to `fs.protected_hardlinks` blocking hard-links to files owned by another user (e.g. Docker uid 500 → host user)
- Falls back to using the source path directly (`is_temp=False`)
- Same-filesystem check still avoids unnecessary `mkstemp` for cross-FS cases

## Context

Discovered during ZODB import from a Docker Swarm FileStorage export. Blob files were owned by uid 500 (Docker plone user), import ran as `jensens`. Hard-link succeeded for some blobs but failed on others with `PermissionError: [Errno 1] Operation not permitted`.

## Test plan

- [ ] Existing blob tests pass
- [ ] Import with blobs owned by different user works

🤖 Generated with [Claude Code](https://claude.com/claude-code)