### PR TITLE
feat: add load_multiple() for batch object loading (#34)

### DIFF
--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -2120,6 +2120,56 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
         self._load_cache.set(zoid, data, tid)
         return data, tid
 
+    def load_multiple(self, oids):
+        """Load multiple objects in a single query.
+
+        Args:
+            oids: iterable of oid bytes
+
+        Returns:
+            dict mapping oid_bytes -> (pickle_bytes, tid_bytes).
+            Only includes oids that exist; missing oids are silently omitted.
+        """
+        result = {}
+        miss_oids = []  # list of (oid_bytes, zoid_int) for cache misses
+
+        for oid in oids:
+            zoid = u64(oid)
+            cached = self._load_cache.get(zoid)
+            if cached is not None:
+                result[oid] = cached
+            else:
+                miss_oids.append((oid, zoid))
+
+        if not miss_oids:
+            return result
+
+        zoid_list = [zoid for _, zoid in miss_oids]
+        zoid_to_oid = {zoid: oid for oid, zoid in miss_oids}
+
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT zoid, tid, class_mod, class_name, state "
+                "FROM object_state WHERE zoid = ANY(%s)",
+                (zoid_list,),
+                prepare=True,
+            )
+            rows = cur.fetchall()
+
+        for row in rows:
+            record = {
+                "@cls": [row["class_mod"], row["class_name"]],
+                "@s": _unsanitize_from_pg(row["state"]),
+            }
+            data = zodb_json_codec.encode_zodb_record(record)
+            tid = p64(row["tid"])
+            oid = zoid_to_oid[row["zoid"]]
+            self._serial_cache[(oid, tid)] = data
+            self._load_cache.set(row["zoid"], data, tid)
+            result[oid] = (data, tid)
+
+        return result
+
     def loadBefore(self, oid, tid):
         """Load object data before a given TID."""
         zoid = u64(oid)

--- a/tests/test_load_multiple.py
+++ b/tests/test_load_multiple.py
@@ -1,0 +1,163 @@
+"""Tests for PGJsonbStorageInstance.load_multiple() batch loading."""
+
+from persistent.mapping import PersistentMapping
+from tests.conftest import DSN
+from ZODB.utils import p64
+from ZODB.utils import u64
+
+import pytest
+import transaction as txn
+
+
+def _pg_available():
+    """Check if test PostgreSQL is reachable."""
+    try:
+        import psycopg
+
+        conn = psycopg.connect(DSN, connect_timeout=2)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _pg_available(),
+    reason="PostgreSQL not available",
+)
+
+
+class TestLoadMultiple:
+    """Tests for the load_multiple() batch loading method."""
+
+    def test_load_multiple_returns_dict(self, db):
+        """load_multiple returns a dict mapping oid -> (data, tid)."""
+        conn = db.open()
+        root = conn.root()
+        root["a"] = PersistentMapping()
+        root["b"] = PersistentMapping()
+        txn.commit()
+
+        oid_a = root["a"]._p_oid
+        oid_b = root["b"]._p_oid
+        conn.close()
+
+        # Get a fresh storage instance to avoid connection-level caching
+        inst = db.storage.new_instance()
+        try:
+            result = inst.load_multiple([oid_a, oid_b])
+
+            assert isinstance(result, dict)
+            assert oid_a in result
+            assert oid_b in result
+
+            # Each value is a (data_bytes, tid_bytes) tuple
+            data_a, tid_a = result[oid_a]
+            assert isinstance(data_a, bytes)
+            assert isinstance(tid_a, bytes)
+            assert len(tid_a) == 8
+
+            data_b, tid_b = result[oid_b]
+            assert isinstance(data_b, bytes)
+            assert isinstance(tid_b, bytes)
+            assert len(tid_b) == 8
+        finally:
+            inst.close()
+
+    def test_load_multiple_caches_results(self, db):
+        """Second call should hit the cache, not the database."""
+        conn = db.open()
+        root = conn.root()
+        root["x"] = PersistentMapping()
+        txn.commit()
+
+        oid_x = root["x"]._p_oid
+        conn.close()
+
+        inst = db.storage.new_instance()
+        try:
+            # First call populates cache
+            result1 = inst.load_multiple([oid_x])
+            assert oid_x in result1
+
+            cache_hits_before = inst._load_cache.hits
+
+            # Second call should use cache
+            result2 = inst.load_multiple([oid_x])
+            assert oid_x in result2
+
+            cache_hits_after = inst._load_cache.hits
+            assert cache_hits_after > cache_hits_before
+
+            # Results should be identical
+            assert result1[oid_x] == result2[oid_x]
+        finally:
+            inst.close()
+
+    def test_load_multiple_skips_missing_oids(self, db):
+        """Missing oids are silently omitted, no POSKeyError raised."""
+        conn = db.open()
+        root = conn.root()
+        root["exists"] = PersistentMapping()
+        txn.commit()
+
+        oid_exists = root["exists"]._p_oid
+        conn.close()
+
+        # Fabricate an oid that does not exist
+        oid_missing = p64(999999999)
+
+        inst = db.storage.new_instance()
+        try:
+            result = inst.load_multiple([oid_exists, oid_missing])
+
+            assert oid_exists in result
+            assert oid_missing not in result
+            assert len(result) == 1
+        finally:
+            inst.close()
+
+    def test_load_multiple_empty_list(self, db):
+        """Passing an empty list returns an empty dict without querying."""
+        inst = db.storage.new_instance()
+        try:
+            result = inst.load_multiple([])
+            assert result == {}
+        finally:
+            inst.close()
+
+    def test_load_multiple_mixed_cached_and_fresh(self, db):
+        """When some oids are cached and others are not, both are returned."""
+        conn = db.open()
+        root = conn.root()
+        root["cached"] = PersistentMapping()
+        root["fresh"] = PersistentMapping()
+        txn.commit()
+
+        oid_cached = root["cached"]._p_oid
+        oid_fresh = root["fresh"]._p_oid
+        conn.close()
+
+        inst = db.storage.new_instance()
+        try:
+            # Pre-load one oid into cache via single load()
+            data_cached, tid_cached = inst.load(oid_cached)
+            cache_hits_before = inst._load_cache.hits
+
+            # Now batch-load both: one cached, one fresh
+            result = inst.load_multiple([oid_cached, oid_fresh])
+
+            assert oid_cached in result
+            assert oid_fresh in result
+
+            # The cached oid should have been a cache hit
+            assert inst._load_cache.hits > cache_hits_before
+
+            # Data for the pre-cached oid should match the single load
+            assert result[oid_cached] == (data_cached, tid_cached)
+
+            # The fresh oid should also be in the cache now
+            fresh_cached = inst._load_cache.get(u64(oid_fresh))
+            assert fresh_cached is not None
+        finally:
+            inst.close()


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluedynamics/zodb-pgjsonb/issues/34 (Part 1)

New `load_multiple(oids)` method on `PGJsonbStorageInstance` that loads multiple objects in a single `SELECT WHERE zoid = ANY()` query instead of individual roundtrips.

- Checks `_load_cache` first, only queries cache misses
- Caches all results in `_load_cache` + `_serial_cache` (same as `load()`)
- Returns `dict[oid, (data, tid)]`, missing oids silently omitted
- 5 tests (skip if no PG)

Part 2 (plone-pgcatalog Brain prefetch integration) in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)