### PR TITLE
fix: skip refs prefetch for ZODB-internal data structures (#40)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.9.1
+
+- Fix refs prefetch over-fetching (#40). Only prefetch refs for
+  content-type objects, not internal ZODB structures
+  (PersistentMapping, OOBTree, etc.) whose refs cascade into massive
+  over-fetching. v1.9.0 made cold-start 40-84% slower; this fix
+  restores the benefit by limiting prefetch to objects that actually
+  have useful sub-objects (annotations, workflows, etc.).
+
 ## 1.9.0
 
 - Prefetch referenced objects on `load()` (#38). When an object is

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -101,6 +101,18 @@ class ExtraColumn:
 # Default cache size: 16 MB per instance (tunable via cache_local_mb parameter)
 DEFAULT_CACHE_LOCAL_MB = 16
 
+# Modules whose objects should NOT trigger refs prefetching (#40).
+# These are ZODB-internal data structures loaded frequently during traversal
+# whose refs point to other internal structures — prefetching them cascades
+# into massive over-fetching.  Application-level objects (OFS, Plone content)
+# are NOT listed here: their refs (annotations, workflows) are worth prefetching.
+_PREFETCH_SKIP_MODULES = (
+    "persistent.",  # PersistentMapping, PersistentList
+    "Persistence.",  # Persistence.mapping.PersistentMapping (C variant)
+    "BTrees.",  # OOBTree, OOBucket, IIBTree, LOBTree, Length, etc.
+    "ZODB.blob",  # Blob objects
+)
+
 # Logarithmic bucket boundaries for blob size histograms.
 _HISTOGRAM_BOUNDARIES = [
     10240,  # 10 KB
@@ -518,9 +530,14 @@ class PGJsonbStorage(ConflictResolvingStorage, BaseStorage):
         self._serial_cache[(oid, tid)] = data
         self._load_cache.set(zoid, data, tid)
 
-        # Prefetch referenced objects (annotations, sub-mappings, etc.)
-        refs = row.get("refs") if isinstance(row, dict) else None
-        if refs:
+        # Prefetch referenced objects, but skip internal ZODB data
+        # structures whose refs cascade into massive over-fetching (#40).
+        # The blacklist covers types that are loaded frequently during
+        # traversal but whose refs are just other internal structures.
+        class_mod = row["class_mod"]
+        if (
+            refs := row.get("refs") if isinstance(row, dict) else None
+        ) and not class_mod.startswith(_PREFETCH_SKIP_MODULES):
             ref_oids = [
                 p64(ref_zoid)
                 for ref_zoid in refs


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluedynamics/zodb-pgjsonb/issues/40

v1.9.0's refs prefetch made cold-start 40-84% slower because every `load()` triggered prefetch, including internal ZODB structures (PersistentMapping, OOBTree) whose refs cascade into massive over-fetching.

### Fix

Skip prefetch when `class_mod` starts with:
- `persistent.` (PersistentMapping, PersistentList)
- `Persistence.` (C variant of PersistentMapping)
- `BTrees.` (OOBTree, OOBucket, Length, etc.)
- `ZODB.blob` (Blob objects)

Application-level objects (OFS, Plone content, anything else) still get prefetch — their refs (annotations, workflows) are worth loading ahead.

### Not Plone-specific

The blacklist only contains pure ZODB-internal modules. OFS and application framework objects are NOT excluded — their annotations and sub-objects benefit from prefetch.

## Test plan
- [ ] CI green
- [ ] Production: cold-start back to v1.8.1 levels or better

🤖 Generated with [Claude Code](https://claude.com/claude-code)