### PR TITLE
fix: run _process_state on undo entries (plone-pgcatalog #30)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.9.3
+
+- Fix ZODB undo nullifying catalog columns (plone-pgcatalog #30).
+  `undo()` now calls `_process_state()` on restored entries (same as
+  `restore()` does), so catalog columns (path, idx, searchable_text,
+  allowed_roles, etc.) are recomputed from the restored state instead
+  of being left as NULL.
+
 ## 1.9.2
 
 - Fix refs prefetch over-fetching (#40). Replace hardcoded class_mod

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -1133,16 +1133,25 @@ class PGJsonbStorage(ConflictResolvingStorage, BaseStorage):
                     }
                 )
             else:
-                self._tmp.append(
-                    {
-                        "zoid": item["zoid"],
-                        "class_mod": item["class_mod"],
-                        "class_name": item["class_name"],
-                        "state": item["state"],
-                        "state_size": item["state_size"],
-                        "refs": item["refs"],
-                    }
+                entry = {
+                    "zoid": item["zoid"],
+                    "class_mod": item["class_mod"],
+                    "class_name": item["class_name"],
+                    "state": item["state"],
+                    "state_size": item["state_size"],
+                    "refs": item["refs"],
+                }
+                # Run state processors so catalog columns are recomputed
+                # from the restored state, not left as NULL.
+                extra = self._process_state(
+                    item["zoid"],
+                    item["class_mod"],
+                    item["class_name"],
+                    item["state"],
                 )
+                if extra:
+                    entry["_extra"] = extra
+                self._tmp.append(entry)
 
         return self._tid, oid_list
 
@@ -2598,16 +2607,26 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
                     }
                 )
             else:
-                self._tmp.append(
-                    {
-                        "zoid": item["zoid"],
-                        "class_mod": item["class_mod"],
-                        "class_name": item["class_name"],
-                        "state": item["state"],
-                        "state_size": item["state_size"],
-                        "refs": item["refs"],
-                    }
+                entry = {
+                    "zoid": item["zoid"],
+                    "class_mod": item["class_mod"],
+                    "class_name": item["class_name"],
+                    "state": item["state"],
+                    "state_size": item["state_size"],
+                    "refs": item["refs"],
+                }
+                # Run state processors so catalog columns (path, idx,
+                # searchable_text, etc.) are recomputed from the restored
+                # state, not left as NULL (#30 in plone-pgcatalog).
+                extra = self._main._process_state(
+                    item["zoid"],
+                    item["class_mod"],
+                    item["class_name"],
+                    item["state"],
                 )
+                if extra:
+                    entry["_extra"] = extra
+                self._tmp.append(entry)
 
         return self._tid, oid_list
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluedynamics/plone-pgcatalog/issues/30

After ZODB undo, all catalog columns (path, idx, searchable_text, allowed_roles) were NULL because `undo()` queued restored states without calling `_process_state()`.

### Fix

Both `PGJsonbStorage.undo()` and `PGJsonbStorageInstance.undo()` now call `_process_state()` on restored entries — same pattern as `restore()`. Catalog columns are recomputed from the restored state.

### Why it works

`_process_state()` runs the `CatalogStateProcessor` which extracts path, idx, searchable_text, allowed_roles from the JSON state. The restored state from undo contains the full object data, so the processor can recompute all columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)