### PR TITLE
fix: main conn idle in transaction after new_oid/reads (#45)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.9.5
+
+- Fix `new_oid()` leaving main connection "idle in transaction"
+  indefinitely (#45).  The main storage connection now uses
+  `autocommit=True` after schema init, so SELECTs (new_oid, load,
+  history, stats) never open implicit transactions.  Write paths
+  that need transactions continue using explicit `BEGIN`/`COMMIT`.
+
 ## 1.9.4
 
 - Enable LZ4 TOAST compression on JSONB and BYTEA columns (PG 14+).

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -326,9 +326,12 @@ class PGJsonbStorage(ConflictResolvingStorage, BaseStorage):
 
         # Load max OID and last TID from database
         self._restore_state()
-        # Commit implicit transaction so self._conn is clean for later DDL
-        # (register_state_processor needs ACCESS EXCLUSIVE for ALTER TABLE)
         self._conn.commit()
+
+        # Switch to autocommit so SELECTs (new_oid, load, history, stats)
+        # don't leave the connection "idle in transaction" indefinitely (#45).
+        # Write paths that need transactions use explicit BEGIN/COMMIT.
+        self._conn.autocommit = True
         logger.debug("Storage initialized (max_oid=%s, ltid=%s)", self._oid, self._ltid)
 
     def _restore_state(self):


### PR DESCRIPTION
## Summary

- Switch `self._conn` (main storage connection) to `autocommit=True` after schema init
- Fixes `new_oid()` and 12+ other read methods leaving the connection "idle in transaction" indefinitely
- Write paths (`tpc_begin`/`tpc_vote`/`tpc_finish`) use explicit `BEGIN`/`COMMIT` and are unaffected

## Root cause

`self._conn` was in default transaction mode. Any SELECT (like `nextval('zoid_seq')` in `new_oid()`) implicitly opens a transaction. If no write follows, the connection stays "idle in transaction" for minutes/hours, visible as stuck connections in `pg_stat_activity`.

## Fix

One line: `self._conn.autocommit = True` after schema init. SELECTs are auto-committed, no implicit transactions. Write paths already use explicit `BEGIN`/`COMMIT`.

Fixes #45

## Test plan

- [x] All existing tests pass (schema init, roundtrips, MVCC, blobs, history, conflict, conformance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)