### PR TITLE
feat: add testcontainers fallback for test PostgreSQL

### DIFF
--- a/src/zodb_pgjsonb/testing.py
+++ b/src/zodb_pgjsonb/testing.py
@@ -39,10 +39,14 @@ Future TODO
 """
 
 import logging
+import os
 import psycopg
 
 
-__all__ = ["TABLES", "PGTestDB"]
+__all__ = ["TABLES", "PGTestDB", "get_test_dsn"]
+
+# Default DSN for local Docker on port 5433 (development setup).
+_DEFAULT_DSN = "dbname=zodb_test user=zodb password=zodb host=localhost port=5433"
 
 log = logging.getLogger(__name__)
 
@@ -212,3 +216,62 @@ class PGTestDB:
     def depth(self):
         """Current snapshot stack depth."""
         return len(self._stack)
+
+
+# -- testcontainers helpers ---------------------------------------------------
+
+
+def get_test_dsn():
+    """Return a PostgreSQL DSN for testing.
+
+    Resolution order:
+    1. ``ZODB_TEST_DSN`` environment variable (CI or explicit override)
+    2. Default local Docker on port 5433 (if reachable)
+    3. testcontainers auto-start (fallback — container stopped via atexit)
+
+    Safe to call multiple times — returns the cached DSN after first call.
+    """
+    if _cache.dsn is not None:
+        return _cache.dsn
+
+    env_dsn = os.environ.get("ZODB_TEST_DSN")
+    if env_dsn:
+        _cache.dsn = env_dsn
+        return _cache.dsn
+
+    # Try the default local Docker container
+    try:
+        conn = psycopg.connect(_DEFAULT_DSN, connect_timeout=2)
+        conn.close()
+        _cache.dsn = _DEFAULT_DSN
+        return _cache.dsn
+    except Exception:
+        pass
+
+    # Fall back to testcontainers
+    from testcontainers.postgres import PostgresContainer
+
+    import atexit
+
+    log.info("No PostgreSQL found — starting testcontainer …")
+    container = PostgresContainer(
+        image="postgres:17",
+        username="zodb",
+        password="zodb",
+        dbname="zodb_test",
+    )
+    container.start()
+    atexit.register(container.stop)
+    _cache.container = container
+
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(5432)
+    _cache.dsn = f"dbname=zodb_test user=zodb password=zodb host={host} port={port}"
+    return _cache.dsn
+
+
+class _cache:
+    """Module-level cache for DSN and optional testcontainer."""
+
+    dsn = None
+    container = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,22 +4,23 @@ Usage:
     pytest                    # all tests (requires PostgreSQL)
     pytest -m "not db"        # fast unit tests only (~1s, no DB needed)
     pytest -m db              # DB integration tests only
+
+PostgreSQL resolution order (via ``zodb_pgjsonb.testing.pg_dsn``):
+    1. ``ZODB_TEST_DSN`` environment variable
+    2. Default local Docker on port 5433
+    3. testcontainers auto-start (fallback)
 """
 
 from zodb_pgjsonb.storage import PGJsonbStorage
+from zodb_pgjsonb.testing import get_test_dsn
 
-import os
 import psycopg
 import pytest
 import ZODB
 
 
-# Allow DSN override via environment variable for CI.
-# Default: local Docker on port 5433 (development setup).
-DSN = os.environ.get(
-    "ZODB_TEST_DSN",
-    "dbname=zodb_test user=zodb password=zodb host=localhost port=5433",
-)
+# Resolved once at import time (testcontainers auto-start if needed).
+DSN = get_test_dsn()
 
 # All tables that may exist across history-free and history-preserving modes.
 ALL_TABLES = (
@@ -37,26 +38,6 @@ ALL_TABLES = (
 _DB_FIXTURES = frozenset({"storage", "db", "hp_storage", "hp_db"})
 
 
-def _pg_available():
-    """Check if the test PostgreSQL is reachable."""
-    try:
-        conn = psycopg.connect(DSN, connect_timeout=2)
-        conn.close()
-        return True
-    except Exception:
-        return False
-
-
-_pg_ok = None  # lazy singleton
-
-
-def _check_pg():
-    global _pg_ok
-    if _pg_ok is None:
-        _pg_ok = _pg_available()
-    return _pg_ok
-
-
 # ── Markers ──────────────────────────────────────────────────────────────
 
 
@@ -65,23 +46,11 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    """Auto-mark tests that use DB fixtures with @pytest.mark.db.
-
-    Tests are marked as DB tests if they:
-    - Use a conftest fixture that needs PG (storage, db, hp_storage, hp_db)
-    - Already carry @pytest.mark.db (set via pytestmark in the test module)
-
-    DB tests are skipped when PostgreSQL is unreachable (graceful degradation).
-    """
-    skip_db = pytest.mark.skip(reason="PostgreSQL not available")
+    """Auto-mark tests that use DB fixtures with @pytest.mark.db."""
     for item in items:
-        # Auto-detect from fixtures
         fixture_names = set(getattr(item, "fixturenames", []))
         if fixture_names & _DB_FIXTURES:
             item.add_marker(pytest.mark.db)
-        # Skip all DB-marked tests if PG is down
-        if item.get_closest_marker("db") and not _check_pg():
-            item.add_marker(skip_db)
 
 
 # ── Database helpers ─────────────────────────────────────────────────────

--- a/tests/test_oid_sequence.py
+++ b/tests/test_oid_sequence.py
@@ -2,18 +2,12 @@
 
 from ZODB.utils import u64
 from zodb_pgjsonb.storage import PGJsonbStorage
+from zodb_pgjsonb.testing import get_test_dsn
 
-import os
 import psycopg
-import pytest
 
 
-DSN = os.environ.get(
-    "ZODB_TEST_DSN",
-    "dbname=zodb_test user=zodb password=zodb host=localhost port=5433",
-)
-
-pytestmark = pytest.mark.skipif(not DSN, reason="No PostgreSQL test database available")
+DSN = get_test_dsn()
 
 
 ALL_TABLES = (


### PR DESCRIPTION
## Summary

- Add `get_test_dsn()` to `zodb_pgjsonb.testing` with 3-tier DSN resolution: `ZODB_TEST_DSN` env var → local Docker on port 5433 → auto-start testcontainer
- Update `conftest.py` and `test_oid_sequence.py` to use `get_test_dsn()` instead of hardcoded `os.environ.get()` patterns
- No manual `docker run` needed before `pytest` anymore — testcontainers starts PG automatically if nothing else is available
- CI unchanged (uses `ZODB_TEST_DSN` env var as before)

## Test plan

- [x] All 442 zodb-pgjsonb tests pass with testcontainers fallback (no Docker container running)
- [x] Verify CI still works with `ZODB_TEST_DSN` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)