### PR TITLE
fix: always defer processor DDL to first write transaction (#100)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.10.3
+
+- Fix startup self-deadlock when processor DDL blocks against own
+  REPEATABLE READ snapshot (#100).  `_apply_processor_ddl()` now
+  always defers DDL to the first write transaction (`tpc_begin()`),
+  when the read snapshot has been committed and ACCESS SHARE released.
+
+- New `defer_startup_action(callable, name)` API for plugins to defer
+  arbitrary startup work (e.g. index creation) to the first write
+  transaction.  Callables receive the DSN as argument.
+
 ## 1.10.2
 
 - Fix instance `load()` not using prefetch refs expression (#40).

--- a/docs/sources/reference/storage-api.md
+++ b/docs/sources/reference/storage-api.md
@@ -325,6 +325,40 @@ existing data.
 : Register a state processor plugin.
   See {doc}`state-processor-api` for the processor protocol.
 
+### Deferred startup actions
+
+`defer_startup_action(action: callable, name: str) -> None`
+: Defer a callable to the first write transaction.
+  *Added in v1.10.3.*
+
+  At Zope startup, a ZODB Connection holds an open `REPEATABLE READ`
+  snapshot with `ACCESS SHARE` on `object_state`.  DDL statements
+  (`ALTER TABLE`, `CREATE INDEX`) need `ACCESS EXCLUSIVE`, which would
+  deadlock against that snapshot.
+
+  This method queues a callable that will be executed during the first
+  `tpc_begin()` call, when the read snapshot has been committed and
+  locks are released.  The callable receives the DSN string as its
+  only argument and should open its own autocommit connection.
+
+  ```python
+  def create_my_index(dsn):
+      import psycopg
+      with psycopg.connect(dsn, autocommit=True) as conn:
+          conn.execute("SET lock_timeout = '30s'")
+          conn.execute(
+              "CREATE INDEX IF NOT EXISTS idx_my_field "
+              "ON object_state ((idx->>'my_field')) "
+              "WHERE idx IS NOT NULL"
+          )
+
+  storage.defer_startup_action(create_my_index, "my_plugin_indexes")
+  ```
+
+  State processor DDL (from `get_schema_sql()`) is automatically
+  deferred — plugins only need this method for additional DDL that
+  is not part of the processor's schema.
+
 ## PGJsonbStorageInstance
 
 ```python

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -472,47 +472,59 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
         logger.info("Prefetch refs expr: %s", sql_expr or "(disabled)")
 
     def _apply_processor_ddl(self, sql, processor_name):
-        """Apply DDL from a state processor, handling lock conflicts.
+        """Defer DDL from a state processor to the first write transaction.
 
-        ALTER TABLE needs ACCESS EXCLUSIVE which conflicts with
-        ACCESS SHARE held by REPEATABLE READ pool connections.
+        At registration time (IDatabaseOpenedWithRoot), a ZODB Connection
+        always holds an open REPEATABLE READ snapshot with ACCESS SHARE on
+        object_state.  DDL (ALTER TABLE, CREATE INDEX) needs ACCESS
+        EXCLUSIVE, which would deadlock against that snapshot (#100).
 
-        During Zope startup, a ZODB Connection loads objects via
-        REPEATABLE READ, holding ACCESS SHARE on object_state.
-        The IDatabaseOpenedWithRoot subscriber fires while that
-        read transaction is still open — so DDL would deadlock.
-
-        Strategy: try with a short lock_timeout.  If blocked,
-        defer the DDL.  It will be applied in tpc_begin() after
-        the read transaction is committed.
+        Always deferring avoids the race entirely.  The DDL runs in
+        ``_apply_pending_ddl()`` called from ``tpc_begin()`` / ``_begin()``
+        when the read transaction has been committed.
         """
-        try:
-            with psycopg.connect(self._dsn, autocommit=True) as ddl_conn:
-                ddl_conn.execute("SET lock_timeout = '2s'")
-                ddl_conn.execute(sql)
-            logger.info("Applied schema DDL from %s", processor_name)
-        except psycopg.errors.LockNotAvailable:
-            logger.info(
-                "DDL from %s deferred (lock conflict at startup). "
-                "Will apply on first write transaction.",
-                processor_name,
-            )
-            self._pending_ddl.append((sql, processor_name))
+        logger.info(
+            "DDL from %s deferred to first write transaction.",
+            processor_name,
+        )
+        self._pending_ddl.append((sql, processor_name))
+
+    def defer_startup_action(self, action, name):
+        """Defer a callable to be executed on the first write transaction.
+
+        Like ``_apply_processor_ddl`` but accepts an arbitrary callable
+        instead of a SQL string.  The callable receives the DSN as its
+        only argument and should open its own autocommit connection.
+
+        Used by plugins (e.g. plone-pgcatalog) to defer index creation
+        that would deadlock against open REPEATABLE READ snapshots at
+        startup.
+        """
+        logger.info("Startup action '%s' deferred to first write transaction.", name)
+        self._pending_ddl.append((action, name))
 
     def _apply_pending_ddl(self):
-        """Apply any deferred DDL.  Called from tpc_begin() after
-        the read transaction is committed (ACCESS SHARE released).
+        """Apply deferred DDL and startup actions.
+
+        Called from ``tpc_begin()`` / ``_begin()`` after the read
+        transaction is committed (ACCESS SHARE released).
+
+        Each entry is either ``(sql_string, name)`` or
+        ``(callable, name)``.  Callables receive ``self._dsn``.
         """
         if not self._pending_ddl:
             return
         pending = self._pending_ddl[:]
         self._pending_ddl.clear()
-        for sql, name in pending:
+        for action, name in pending:
             try:
-                with psycopg.connect(self._dsn, autocommit=True) as ddl_conn:
-                    ddl_conn.execute("SET lock_timeout = '30s'")
-                    ddl_conn.execute(sql)
-                logger.info("Applied deferred schema DDL from %s", name)
+                if callable(action):
+                    action(self._dsn)
+                else:
+                    with psycopg.connect(self._dsn, autocommit=True) as ddl_conn:
+                        ddl_conn.execute("SET lock_timeout = '30s'")
+                        ddl_conn.execute(action)
+                logger.info("Applied deferred DDL/action from %s", name)
             except Exception:
                 logger.warning(
                     "Failed to apply deferred DDL from %s "


### PR DESCRIPTION
## Summary

Companion to bluedynamics/plone-pgcatalog#102.

- `_apply_processor_ddl()` no longer attempts immediate DDL at startup — always defers to `_pending_ddl`
- New `defer_startup_action(callable, name)` API for plugins to defer arbitrary startup work
- `_apply_pending_ddl()` handles both SQL strings and callables

**Why:** At registration time (IDatabaseOpenedWithRoot), a ZODB Connection holds an open REPEATABLE READ snapshot. DDL needs ACCESS EXCLUSIVE → self-deadlock. Deferring to `tpc_begin()` avoids it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)