### PR TITLE
fix: apply deferred DDL on first read, not just write

### DIFF
--- a/src/zodb_pgjsonb/instance.py
+++ b/src/zodb_pgjsonb/instance.py
@@ -139,6 +139,14 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
         # End any previous read snapshot
         self._end_read_txn()
 
+        # Apply any DDL deferred from startup (e.g. ALTER TABLE ADD COLUMN)
+        # before starting the read snapshot.  At this point the startup
+        # REPEATABLE READ has been committed, so ACCESS SHARE is released
+        # and the DDL can acquire ACCESS EXCLUSIVE.  Without this, a
+        # read-only request that hits a column added by a state processor
+        # (e.g. 'meta') would crash with UndefinedColumn (#105).
+        self._main._apply_pending_ddl()
+
         # Start a new REPEATABLE READ snapshot immediately.
         # The first query anchors the snapshot — all subsequent queries
         # (invalidation lookups AND load() calls) see this same state.

--- a/tests/test_state_processor.py
+++ b/tests/test_state_processor.py
@@ -409,3 +409,69 @@ class TestFinalizeHook:
 
         assert len(self.proc.finalize_calls) == 0
         conn.close()
+
+
+# ── Deferred DDL on read path (#105) ────────────────────────────────
+
+
+class DDLProcessor:
+    """Processor that provides DDL adding a column."""
+
+    def get_extra_columns(self):
+        return [ExtraColumn("ddl_test_col", "%(ddl_test_col)s")]
+
+    def get_schema_sql(self):
+        return "ALTER TABLE object_state ADD COLUMN IF NOT EXISTS ddl_test_col TEXT"
+
+    def process(self, zoid, class_mod, class_name, state):
+        return None
+
+
+class TestDeferredDDLOnReadPath:
+    """DDL deferred from startup must be applied on first read, not just write.
+
+    Regression test for #105: if the first request after startup is a
+    read-only GET, poll_invalidations() must apply pending DDL so that
+    queries referencing new columns don't crash with UndefinedColumn.
+    """
+
+    def test_poll_invalidations_applies_pending_ddl(self):
+        clean_db()
+        storage = PGJsonbStorage(DSN)
+        try:
+            # Register processor — DDL is deferred to _pending_ddl
+            storage.register_state_processor(DDLProcessor())
+            assert len(storage._pending_ddl) > 0, "DDL should be deferred"
+
+            # Column should NOT exist yet
+            pg = psycopg.connect(DSN, row_factory=dict_row)
+            with pg.cursor() as cur:
+                cur.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'object_state' "
+                    "AND column_name = 'ddl_test_col'"
+                )
+                assert cur.fetchone() is None, "Column must not exist before poll"
+            pg.close()
+
+            # Create an instance and call poll_invalidations (read path)
+            instance = storage.new_instance()
+            try:
+                instance.poll_invalidations()
+
+                # DDL should have been applied — column now exists
+                pg = psycopg.connect(DSN, row_factory=dict_row)
+                with pg.cursor() as cur:
+                    cur.execute(
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_name = 'object_state' "
+                        "AND column_name = 'ddl_test_col'"
+                    )
+                    row = cur.fetchone()
+                pg.close()
+                assert row is not None, "Column should exist after poll_invalidations"
+                assert len(storage._pending_ddl) == 0, "Pending DDL should be cleared"
+            finally:
+                instance.release()
+        finally:
+            storage.close()


### PR DESCRIPTION
## Summary

Fixes bluedynamics/plone-pgcatalog#105

After upgrading to a version that adds new columns via state processors (e.g. `meta`), the first **read** request crashes with `UndefinedColumn` because DDL was deferred and only applied on the first **write** transaction.

### Root Cause

`_apply_pending_ddl()` was only called from:
- `_begin()` on the main storage (write path)
- `tpc_begin()` on the instance (write path)

But `poll_invalidations()` (read path) never applied pending DDL, so columns added by state processors didn't exist when read queries referenced them.

### Fix

Call `self._main._apply_pending_ddl()` in `poll_invalidations()` after `_end_read_txn()` (ACCESS SHARE released) and before `_begin_read_txn()` (new snapshot). At this point the startup handler has returned and no locks block the DDL.

### Defense-in-depth

A companion PR on plone-pgcatalog adds a try/except fallback in `brain.py:_load_idx_batch()` to gracefully handle the missing `meta` column.

## Test plan

- [x] New test `test_poll_invalidations_applies_pending_ddl` — verifies DDL column exists after first poll
- [x] All 17 state processor tests pass
- [x] All 21 MVCC tests pass (poll_invalidations behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)