### PR TITLE
Serialize startup DDL across replicas via PG advisory lock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Serialize startup DDL across replicas via session-level PostgreSQL
+  advisory lock.  New `zodb_pgjsonb.startup_locks` module exposes
+  `startup_ddl_lock(dsn)` context manager.  `_apply_pending_ddl` wraps
+  its body in the lock and requeues pending work on timeout.  Lock wait
+  timeout is 15 minutes by default, overridable via
+  `ZODB_PGJSONB_DDL_LOCK_TIMEOUT`.  Closes
+  bluedynamics/plone-pgcatalog#108 (credit: @davisagli).
+
 ## 1.10.4
 
 - Apply deferred processor DDL on first read, not just first write

--- a/src/zodb_pgjsonb/startup_locks.py
+++ b/src/zodb_pgjsonb/startup_locks.py
@@ -1,0 +1,72 @@
+"""Session-level PostgreSQL advisory locks for startup DDL coordination.
+
+Serializes ``_apply_pending_ddl`` across replicas so only one process at a
+time runs schema DDL and deferred startup actions.  Non-winners wait on
+``pg_advisory_lock`` and then find the work already done (idempotent DDL).
+
+See docs/superpowers/specs/2026-04-10-startup-ddl-advisory-lock-design.md.
+"""
+
+from contextlib import contextmanager
+
+import logging
+import os
+import psycopg
+
+
+log = logging.getLogger(__name__)
+
+# Advisory lock coordinates — two-arg form keeps us in a separate keyspace
+# from ``pg_advisory_xact_lock(0)`` used for TID serialization.
+STARTUP_DDL_LOCK_NS = 0x5A4442  # "ZDB"
+STARTUP_DDL_LOCK_KEY = 1  # startup DDL serializer
+
+DEFAULT_TIMEOUT = "15min"
+ENV_TIMEOUT = "ZODB_PGJSONB_DDL_LOCK_TIMEOUT"
+
+
+@contextmanager
+def startup_ddl_lock(dsn, timeout=None):
+    """Acquire a session-level PG advisory lock for startup DDL.
+
+    Opens a dedicated autocommit connection, sets ``lock_timeout``, then
+    calls ``pg_advisory_lock(ns, key)``.  The lock is held for the full
+    body of the ``with`` block and released via ``pg_advisory_unlock``.
+    If the process crashes, PostgreSQL auto-releases on session close.
+
+    Args:
+        dsn: PostgreSQL connection string.
+        timeout: ``SET lock_timeout`` value (e.g. "15min").  Defaults to
+            ``$ZODB_PGJSONB_DDL_LOCK_TIMEOUT`` or "15min".
+
+    Raises:
+        psycopg.errors.LockNotAvailable: if the lock cannot be acquired
+            within ``timeout``.
+    """
+    effective_timeout = timeout or os.environ.get(ENV_TIMEOUT) or DEFAULT_TIMEOUT
+    conn = psycopg.connect(dsn, autocommit=True)
+    try:
+        conn.execute(f"SET lock_timeout = '{effective_timeout}'")
+        conn.execute(
+            "SELECT pg_advisory_lock(%s, %s)",
+            (STARTUP_DDL_LOCK_NS, STARTUP_DDL_LOCK_KEY),
+        )
+        log.debug(
+            "Acquired startup DDL advisory lock (%s, %s)",
+            STARTUP_DDL_LOCK_NS,
+            STARTUP_DDL_LOCK_KEY,
+        )
+        try:
+            yield conn
+        finally:
+            try:
+                conn.execute(
+                    "SELECT pg_advisory_unlock(%s, %s)",
+                    (STARTUP_DDL_LOCK_NS, STARTUP_DDL_LOCK_KEY),
+                )
+            except Exception:
+                log.warning(
+                    "Failed to release startup DDL advisory lock", exc_info=True
+                )
+    finally:
+        conn.close()

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -23,6 +23,7 @@ from .schema import HISTORY_PRESERVING_ADDITIONS
 from .schema import install_schema
 from .serialization import _deserialize_extension
 from .serialization import _unsanitize_from_pg
+from .startup_locks import startup_ddl_lock
 from .stats import get_blob_histogram as _get_blob_histogram
 from .stats import get_blob_stats as _get_blob_stats
 from .undo import _compute_undo
@@ -511,27 +512,43 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
 
         Each entry is either ``(sql_string, name)`` or
         ``(callable, name)``.  Callables receive ``self._dsn``.
+
+        Wraps the whole batch in a session-level PG advisory lock so
+        concurrent replicas serialize their DDL.  On lock timeout, the
+        pending entries are requeued for the next call.
         """
         if not self._pending_ddl:
             return
         pending = self._pending_ddl[:]
         self._pending_ddl.clear()
-        for action, name in pending:
-            try:
-                if callable(action):
-                    action(self._dsn)
-                else:
-                    with psycopg.connect(self._dsn, autocommit=True) as ddl_conn:
-                        ddl_conn.execute("SET lock_timeout = '30s'")
-                        ddl_conn.execute(action)
-                logger.info("Applied deferred DDL/action from %s", name)
-            except Exception:
-                logger.warning(
-                    "Failed to apply deferred DDL from %s "
-                    "(lock timeout or other error — will retry on next startup)",
-                    name,
-                    exc_info=True,
-                )
+        try:
+            with startup_ddl_lock(self._dsn):
+                for action, name in pending:
+                    try:
+                        if callable(action):
+                            action(self._dsn)
+                        else:
+                            with psycopg.connect(
+                                self._dsn, autocommit=True
+                            ) as ddl_conn:
+                                ddl_conn.execute("SET lock_timeout = '30s'")
+                                ddl_conn.execute(action)
+                        logger.info("Applied deferred DDL/action from %s", name)
+                    except Exception:
+                        logger.warning(
+                            "Failed to apply deferred DDL from %s "
+                            "(lock timeout or other error — will retry on next startup)",
+                            name,
+                            exc_info=True,
+                        )
+        except psycopg.errors.LockNotAvailable:
+            # Could not acquire the startup lock — requeue pending work
+            # so the next tpc_begin / poll_invalidations retries.
+            self._pending_ddl = pending + self._pending_ddl
+            logger.warning(
+                "Could not acquire startup DDL advisory lock within timeout — "
+                "will retry on next tpc_begin / poll_invalidations",
+            )
 
     def _process_state(self, zoid, class_mod, class_name, state):
         """Run all registered state processors, return merged extra data."""

--- a/tests/test_startup_ddl_serialization.py
+++ b/tests/test_startup_ddl_serialization.py
@@ -1,0 +1,128 @@
+"""Integration tests for startup DDL advisory lock serialization.
+
+Requires a running PostgreSQL on localhost:5433 (see conftest.py).
+"""
+
+from tests.conftest import clean_db
+from tests.conftest import DSN
+
+import pytest
+import threading
+import time
+
+
+pytestmark = pytest.mark.db
+
+
+def test_apply_pending_ddl_serializes_across_threads():
+    """Two concurrent `_apply_pending_ddl` calls run sequentially."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        started = []
+        finished = []
+        barrier = threading.Barrier(2)
+        lock = threading.Lock()
+
+        def slow_action(dsn):
+            with lock:
+                started.append(time.monotonic())
+            time.sleep(0.5)
+            with lock:
+                finished.append(time.monotonic())
+
+        def worker():
+            storage._pending_ddl.append((slow_action, "slow"))
+            barrier.wait()
+            storage._apply_pending_ddl()
+
+        t1 = threading.Thread(target=worker)
+        t2 = threading.Thread(target=worker)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        assert len(started) == 2
+        assert len(finished) == 2
+        # Second action must start AFTER first action finishes
+        started.sort()
+        finished.sort()
+        assert started[1] >= finished[0] - 0.05  # 50ms scheduling slack
+    finally:
+        storage.close()
+
+
+def test_apply_pending_ddl_requeues_on_lock_timeout():
+    """When lock is held externally, pending work is requeued."""
+    from zodb_pgjsonb.startup_locks import STARTUP_DDL_LOCK_KEY
+    from zodb_pgjsonb.startup_locks import STARTUP_DDL_LOCK_NS
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    import os
+    import psycopg
+
+    clean_db()
+    # Acquire the lock from a separate connection, hold it.
+    holder = psycopg.connect(DSN, autocommit=True)
+    holder.execute(
+        "SELECT pg_advisory_lock(%s, %s)",
+        (STARTUP_DDL_LOCK_NS, STARTUP_DDL_LOCK_KEY),
+    )
+    try:
+        storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+        try:
+            # Queue an action; expect it to be requeued after timeout.
+            def noop_action(dsn):
+                pass
+
+            storage._pending_ddl.append((noop_action, "noop"))
+
+            # Force a very short timeout via env var.
+            old = os.environ.get("ZODB_PGJSONB_DDL_LOCK_TIMEOUT")
+            os.environ["ZODB_PGJSONB_DDL_LOCK_TIMEOUT"] = "500ms"
+            try:
+                storage._apply_pending_ddl()
+            finally:
+                if old is None:
+                    del os.environ["ZODB_PGJSONB_DDL_LOCK_TIMEOUT"]
+                else:
+                    os.environ["ZODB_PGJSONB_DDL_LOCK_TIMEOUT"] = old
+
+            # Pending work was requeued, not lost
+            assert len(storage._pending_ddl) == 1
+            assert storage._pending_ddl[0][1] == "noop"
+        finally:
+            storage.close()
+    finally:
+        holder.execute(
+            "SELECT pg_advisory_unlock(%s, %s)",
+            (STARTUP_DDL_LOCK_NS, STARTUP_DDL_LOCK_KEY),
+        )
+        holder.close()
+
+
+def test_lock_released_when_holder_disconnects():
+    """PG auto-releases the advisory lock on session disconnect."""
+    from zodb_pgjsonb.startup_locks import startup_ddl_lock
+    from zodb_pgjsonb.startup_locks import STARTUP_DDL_LOCK_KEY
+    from zodb_pgjsonb.startup_locks import STARTUP_DDL_LOCK_NS
+
+    import psycopg
+
+    clean_db()
+    # Session 1: acquire then close without unlock
+    s1 = psycopg.connect(DSN, autocommit=True)
+    s1.execute(
+        "SELECT pg_advisory_lock(%s, %s)",
+        (STARTUP_DDL_LOCK_NS, STARTUP_DDL_LOCK_KEY),
+    )
+    s1.close()  # auto-release on disconnect
+
+    # Session 2: should acquire immediately
+    start = time.monotonic()
+    with startup_ddl_lock(DSN, timeout="1s"):
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.5

--- a/tests/test_startup_locks.py
+++ b/tests/test_startup_locks.py
@@ -1,5 +1,9 @@
 """Tests for zodb_pgjsonb.startup_locks."""
 
+from unittest import mock
+
+import pytest
+
 
 def test_lock_namespace_and_key_constants():
     from zodb_pgjsonb.startup_locks import STARTUP_DDL_LOCK_KEY
@@ -7,3 +11,68 @@ def test_lock_namespace_and_key_constants():
 
     assert STARTUP_DDL_LOCK_NS == 0x5A4442  # "ZDB"
     assert STARTUP_DDL_LOCK_KEY == 1
+
+
+def test_context_manager_sql_sequence():
+    """Verify exact SQL sequence issued on acquire + release."""
+    from zodb_pgjsonb.startup_locks import startup_ddl_lock
+    from zodb_pgjsonb.startup_locks import STARTUP_DDL_LOCK_KEY
+    from zodb_pgjsonb.startup_locks import STARTUP_DDL_LOCK_NS
+
+    fake_conn = mock.MagicMock()
+    with (
+        mock.patch(
+            "zodb_pgjsonb.startup_locks.psycopg.connect", return_value=fake_conn
+        ),
+        startup_ddl_lock("dsn=test", timeout="2s"),
+    ):
+        pass
+
+    calls = fake_conn.execute.call_args_list
+    # SET lock_timeout, pg_advisory_lock, pg_advisory_unlock
+    assert calls[0].args[0] == "SET lock_timeout = '2s'"
+    assert calls[1].args[0] == "SELECT pg_advisory_lock(%s, %s)"
+    assert calls[1].args[1] == (STARTUP_DDL_LOCK_NS, STARTUP_DDL_LOCK_KEY)
+    assert calls[2].args[0] == "SELECT pg_advisory_unlock(%s, %s)"
+    assert calls[2].args[1] == (STARTUP_DDL_LOCK_NS, STARTUP_DDL_LOCK_KEY)
+    fake_conn.close.assert_called_once()
+
+
+def test_env_var_overrides_default_timeout():
+    """ZODB_PGJSONB_DDL_LOCK_TIMEOUT overrides the 15min default."""
+    from zodb_pgjsonb.startup_locks import startup_ddl_lock
+
+    fake_conn = mock.MagicMock()
+    with (
+        mock.patch(
+            "zodb_pgjsonb.startup_locks.psycopg.connect", return_value=fake_conn
+        ),
+        mock.patch.dict("os.environ", {"ZODB_PGJSONB_DDL_LOCK_TIMEOUT": "42s"}),
+        startup_ddl_lock("dsn=test"),
+    ):
+        pass
+
+    first_sql = fake_conn.execute.call_args_list[0].args[0]
+    assert first_sql == "SET lock_timeout = '42s'"
+
+
+def test_release_happens_on_exception():
+    """Lock is released even when the body raises."""
+    from zodb_pgjsonb.startup_locks import startup_ddl_lock
+
+    fake_conn = mock.MagicMock()
+    with (
+        mock.patch(
+            "zodb_pgjsonb.startup_locks.psycopg.connect", return_value=fake_conn
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+        startup_ddl_lock("dsn=test", timeout="1s"),
+    ):
+        raise RuntimeError("boom")
+
+    # Verify unlock was called and connection closed
+    unlock_calls = [
+        c for c in fake_conn.execute.call_args_list if "pg_advisory_unlock" in c.args[0]
+    ]
+    assert len(unlock_calls) == 1
+    fake_conn.close.assert_called_once()

--- a/tests/test_startup_locks.py
+++ b/tests/test_startup_locks.py
@@ -1,0 +1,9 @@
+"""Tests for zodb_pgjsonb.startup_locks."""
+
+
+def test_lock_namespace_and_key_constants():
+    from zodb_pgjsonb.startup_locks import STARTUP_DDL_LOCK_KEY
+    from zodb_pgjsonb.startup_locks import STARTUP_DDL_LOCK_NS
+
+    assert STARTUP_DDL_LOCK_NS == 0x5A4442  # "ZDB"
+    assert STARTUP_DDL_LOCK_KEY == 1


### PR DESCRIPTION
## Summary

- New `zodb_pgjsonb.startup_locks` module exposing `startup_ddl_lock(dsn)` context manager — session-level two-arg PG advisory lock `(0x5A4442, 1)` in a separate keyspace from the existing `pg_advisory_xact_lock(0)` TID lock
- `_apply_pending_ddl()` wraps its body in the advisory lock; concurrent replicas serialize DDL automatically
- On `LockNotAvailable`, pending entries are requeued for the next `tpc_begin` / `poll_invalidations` — no work is lost
- Lock wait timeout defaults to 15 minutes, overridable via `ZODB_PGJSONB_DDL_LOCK_TIMEOUT`
- 7 new tests (4 unit + 3 integration), coverage 91.04% → 91.75%
- Closes bluedynamics/plone-pgcatalog#108 (credit: @davisagli for the approach)

## Background

In multi-replica Kubernetes deployments, every pod tries to run deferred DDL at startup, causing `LockNotAvailable` errors from ACCESS EXCLUSIVE contention. This PR makes only one pod at a time run DDL; others wait on the advisory lock, then find the work already done (idempotent DDL).

Spec: `docs/superpowers/specs/2026-04-10-startup-ddl-advisory-lock-design.md`

## Deadlock analysis (no cycles possible)

| Scenario | Outcome |
|--|--|
| 6 pods in `_apply_pending_ddl` simultaneously | One wins, others block, find DDL done (no-op) |
| Pod A DDL waits for pod B ACCESS SHARE | Same as today; `lock_timeout=30s` bounds wait |
| Pod A crashes holding advisory lock | PG auto-releases on session disconnect |
| Lock acquisition times out | `LockNotAvailable` → requeue → retry next tpc_begin |

Intra-process ACCESS SHARE × EXCLUSIVE conflicts are already prevented by existing `_end_read_txn()` calls on every `_apply_pending_ddl` call path.

## Test plan

- [x] All 455 tests pass (was 448 baseline; +7 new)
- [x] Coverage 91.75% (was 91.04%)
- [x] New module `startup_locks.py` at 92% coverage
- [x] ruff check + format clean (pre-commit hooks)
- [x] Integration test verifies two concurrent `_apply_pending_ddl` calls are serialized (serial 0.5s × 2)
- [x] Integration test verifies requeue-on-timeout preserves pending work
- [x] Integration test verifies session disconnect auto-releases the lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)