### PR TITLE
Close read txn at request end (afterCompletion) + idle-in-xact safety net (#118)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+- Implement `IStorage.afterCompletion()` on `PGJsonbStorageInstance`
+  so the REPEATABLE READ read-snapshot transaction is committed at
+  request end (after every `transaction.commit/abort` and on
+  `Connection.close()`).  Previously the read tx persisted across
+  request boundaries until the connection was reused, leaving
+  `idle in transaction` sessions with live virtualxids that blocked
+  `CREATE INDEX CONCURRENTLY` for minutes-to-hours under load.
+  Idempotent and exception-swallowing — a connection killed
+  externally is logged and rebuilt on next use.  Closes
+  bluedynamics/plone-pgcatalog#118.
+
+- Set `idle_in_transaction_session_timeout` (default 60_000 ms,
+  env-overridable via `ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS`) on
+  every connection from the instance pool.  Defense in depth for
+  any future leak path that bypasses `afterCompletion` (e.g.
+  `SIGKILL`-ed worker, buggy plugin).  Set to `0` to disable.
+
 ## 1.10.4
 
 - Apply deferred processor DDL on first read, not just first write

--- a/docs/superpowers/plans/2026-04-13-idle-in-xact-zodb-pgjsonb.md
+++ b/docs/superpowers/plans/2026-04-13-idle-in-xact-zodb-pgjsonb.md
@@ -1,0 +1,569 @@
+# Idle-in-Transaction Fix: zodb-pgjsonb (PR1) — Implementation Plan
+
+**Goal:** Stop `PGJsonbStorageInstance` leaking REPEATABLE READ transactions across requests so they no longer block `CREATE INDEX CONCURRENTLY`.
+
+**Architecture:**
+1. Implement `IStorage.afterCompletion()` on `PGJsonbStorageInstance` — calls `_end_read_txn()`, idempotent, never raises.  ZODB calls it after every transaction commit/abort and on `Connection.close()`.
+2. Apply `idle_in_transaction_session_timeout` (default 60_000ms, env-overridable) to every PG connection the instance pool hands out — defense in depth.
+
+**Tech Stack:** psycopg 3, psycopg_pool, ZODB, pytest
+
+**Spec:** `docs/superpowers/specs/2026-04-13-idle-in-xact-design.md`
+
+---
+
+## File Map
+
+- Modify: `src/zodb_pgjsonb/instance.py` — add `afterCompletion`
+- Modify: `src/zodb_pgjsonb/storage.py` — pool `configure` hook applies the idle timeout (replacing the inline `lambda`)
+- Create: `tests/test_idle_in_xact.py` — integration tests (require PG)
+- Modify: `CHANGES.md` — Unreleased entry
+
+---
+
+### Task 1: Failing test — `afterCompletion` should close read txn
+
+**Files:**
+- Create: `tests/test_idle_in_xact.py`
+
+- [ ] **Step 1: Write the test file with one failing test**
+
+```python
+"""Tests for #118: read tx must be closed at request end so virtualxids
+don't accumulate and block CREATE INDEX CONCURRENTLY.
+"""
+
+from tests.conftest import clean_db
+from tests.conftest import DSN
+
+import psycopg
+import pytest
+
+
+pytestmark = pytest.mark.db
+
+
+def _backend_state(monitor_conn, pid):
+    """Return (state, xact_age_seconds) for a backend pid via a separate conn."""
+    with monitor_conn.cursor() as cur:
+        cur.execute(
+            "SELECT state, "
+            "EXTRACT(EPOCH FROM (now() - xact_start)) AS xact_age "
+            "FROM pg_stat_activity WHERE pid = %s",
+            (pid,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return (None, None)
+        return (row["state"], row["xact_age"])
+
+
+def test_after_completion_closes_read_txn():
+    """afterCompletion() must end the REPEATABLE READ snapshot."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        instance = storage.new_instance()
+        try:
+            # poll_invalidations opens the read txn
+            instance.poll_invalidations()
+            assert instance._in_read_txn is True
+
+            # afterCompletion must close it
+            instance.afterCompletion()
+            assert instance._in_read_txn is False
+        finally:
+            instance.release()
+    finally:
+        storage.close()
+```
+
+- [ ] **Step 2: Verify the test fails before the fix**
+
+Run: `PYTHONPATH=src .venv/bin/pytest tests/test_idle_in_xact.py::test_after_completion_closes_read_txn -v`
+Expected: FAIL with `AttributeError: ... 'PGJsonbStorageInstance' object has no attribute 'afterCompletion'`.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/test_idle_in_xact.py
+git commit -m "test: failing regression for #118 — read txn must close on afterCompletion"
+```
+
+---
+
+### Task 2: Implement `afterCompletion` on `PGJsonbStorageInstance`
+
+**Files:**
+- Modify: `src/zodb_pgjsonb/instance.py` (add method right after `release` at ~line 111)
+
+- [ ] **Step 1: Add the method**
+
+Locate `def _end_read_txn(self):` at line 113.  Insert this *before* it (right after `release`):
+
+```python
+    def afterCompletion(self):
+        """ZODB hook: end any open REPEATABLE READ snapshot.
+
+        Called by ZODB after every transaction commit/abort and on
+        ``Connection.close()`` (see ``ZODB.Connection.close``).
+        Closing the read transaction at request end avoids holding a
+        ``virtualxid`` that blocks ``CREATE INDEX CONCURRENTLY`` and
+        similar maintenance operations (#118).
+
+        Idempotent: ``_end_read_txn`` short-circuits when no read tx
+        is open (e.g. right after a write transaction's ``tpc_begin``
+        already ended it).  Never raises — the connection may have
+        been killed by an external operator or by
+        ``idle_in_transaction_session_timeout``; in that case we just
+        log and let the next operation rebuild via the pool.
+        """
+        try:
+            self._end_read_txn()
+        except Exception:
+            log.warning("afterCompletion: _end_read_txn failed", exc_info=True)
+```
+
+Verify the file already imports `log` at module top: open the file, search for `^log = ` or `import logging`.  If absent, add at the top of `instance.py`:
+
+```python
+import logging
+
+log = logging.getLogger(__name__)
+```
+
+(If a logger exists under a different name like `logger`, use it instead of introducing `log`.)
+
+- [ ] **Step 2: Run the previously-failing test**
+
+Run: `PYTHONPATH=src .venv/bin/pytest tests/test_idle_in_xact.py::test_after_completion_closes_read_txn -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full test suite, no regressions**
+
+Run: `PYTHONPATH=src .venv/bin/pytest -q`
+Expected: same baseline (allowing 5 pre-existing test_oid_sequence failures unrelated to this change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/zodb_pgjsonb/instance.py
+git commit -m "fix(instance): implement afterCompletion to close read txn at request end (#118)"
+```
+
+---
+
+### Task 3: Edge-case tests for `afterCompletion`
+
+**Files:**
+- Modify: `tests/test_idle_in_xact.py`
+
+- [ ] **Step 1: Append more tests**
+
+Append after the first test:
+
+```python
+def test_after_completion_idempotent():
+    """Calling afterCompletion twice in a row is safe."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        instance = storage.new_instance()
+        try:
+            instance.poll_invalidations()
+            instance.afterCompletion()
+            # Second call: no-op, no error
+            instance.afterCompletion()
+            assert instance._in_read_txn is False
+        finally:
+            instance.release()
+    finally:
+        storage.close()
+
+
+def test_after_completion_no_op_after_tpc_begin():
+    """tpc_begin already ends the read tx — afterCompletion is a no-op then."""
+    import transaction as txn
+    from persistent.mapping import PersistentMapping
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    import ZODB
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        db = ZODB.DB(storage)
+        try:
+            conn = db.open()
+            root = conn.root()
+            root["x"] = PersistentMapping({"k": "v"})
+            txn.commit()
+            instance = conn._storage
+            # After commit, read tx should be closed (commit path ends it)
+            instance.afterCompletion()
+            assert instance._in_read_txn is False
+            conn.close()
+        finally:
+            db.close()
+    finally:
+        storage.close()
+
+
+def test_after_completion_safe_when_conn_killed():
+    """If the conn is externally terminated, afterCompletion must not raise."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        instance = storage.new_instance()
+        try:
+            instance.poll_invalidations()
+            assert instance._in_read_txn is True
+
+            # Kill the backend from a separate session
+            pid = instance._conn.info.backend_pid
+            killer = psycopg.connect(DSN)
+            try:
+                killer.execute(
+                    "SELECT pg_terminate_backend(%s)", (pid,)
+                )
+                killer.commit()
+            finally:
+                killer.close()
+
+            # afterCompletion must swallow the resulting connection error
+            instance.afterCompletion()  # must not raise
+        finally:
+            # Force release without raising — conn is dead
+            try:
+                instance.release()
+            except Exception:
+                pass
+    finally:
+        try:
+            storage.close()
+        except Exception:
+            pass
+
+
+def test_zodb_connection_close_releases_virtualxid():
+    """End-to-end: a read-only ZODB transaction releases its virtualxid.
+
+    Without afterCompletion, this would leave 'idle in transaction' on
+    the storage instance's PG connection.
+    """
+    import transaction as txn
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    import ZODB
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        db = ZODB.DB(storage)
+        try:
+            conn = db.open()
+            instance = conn._storage
+            _ = conn.root()  # triggers poll_invalidations + a load
+            assert instance._in_read_txn is True
+
+            pid = instance._conn.info.backend_pid
+
+            # Abort the (read-only) transaction — synchronizer fires
+            # afterCompletion via Connection.afterCompletion.
+            txn.abort()
+
+            # Read tx must now be closed.
+            assert instance._in_read_txn is False
+
+            # Confirm via pg_stat_activity that the backend is idle
+            # (not "idle in transaction").
+            monitor = psycopg.connect(DSN, row_factory=__import__(
+                "psycopg.rows", fromlist=["dict_row"]
+            ).dict_row)
+            try:
+                state, _age = _backend_state(monitor, pid)
+                assert state == "idle", f"Expected idle, got {state!r}"
+            finally:
+                monitor.close()
+
+            conn.close()
+        finally:
+            db.close()
+    finally:
+        storage.close()
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `PYTHONPATH=src .venv/bin/pytest tests/test_idle_in_xact.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_idle_in_xact.py
+git commit -m "test: edge cases for afterCompletion (idempotent, post-tpc, killed conn, end-to-end)"
+```
+
+---
+
+### Task 4: Failing test — `idle_in_transaction_session_timeout` configured
+
+**Files:**
+- Modify: `tests/test_idle_in_xact.py`
+
+- [ ] **Step 1: Add the test**
+
+Append:
+
+```python
+def test_idle_timeout_set_on_pool_conn():
+    """Every conn from the instance pool has idle_in_transaction_session_timeout set."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        with storage._instance_pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT current_setting('idle_in_transaction_session_timeout') AS v"
+                )
+                row = cur.fetchone()
+        # Default 60_000 ms, may include unit suffix (e.g. '60000' or '1min')
+        # PostgreSQL typically returns the value as the number of ms with no suffix
+        # when set via numeric: '60000'.
+        assert row["v"] in ("60000", "1min")
+    finally:
+        storage.close()
+
+
+def test_idle_timeout_env_override():
+    """ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS env var overrides default."""
+    import os
+
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    old = os.environ.get("ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS")
+    os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"] = "5000"
+    try:
+        storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+        try:
+            with storage._instance_pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT current_setting('idle_in_transaction_session_timeout') AS v"
+                    )
+                    row = cur.fetchone()
+            assert row["v"] == "5000"
+        finally:
+            storage.close()
+    finally:
+        if old is None:
+            del os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"]
+        else:
+            os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"] = old
+
+
+def test_idle_timeout_disabled_when_zero():
+    """Setting the env var to 0 disables the timeout (PG default)."""
+    import os
+
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    old = os.environ.get("ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS")
+    os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"] = "0"
+    try:
+        storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+        try:
+            with storage._instance_pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT current_setting('idle_in_transaction_session_timeout') AS v"
+                    )
+                    row = cur.fetchone()
+            assert row["v"] == "0"
+        finally:
+            storage.close()
+    finally:
+        if old is None:
+            del os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"]
+        else:
+            os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"] = old
+```
+
+- [ ] **Step 2: Verify the first one fails (default not configured yet)**
+
+Run: `PYTHONPATH=src .venv/bin/pytest tests/test_idle_in_xact.py::test_idle_timeout_set_on_pool_conn -v`
+Expected: FAIL — current setting is `'0'` (PG default).
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/test_idle_in_xact.py
+git commit -m "test: failing regression for default idle_in_transaction_session_timeout (#118)"
+```
+
+---
+
+### Task 5: Implement the pool `configure` hook
+
+**Files:**
+- Modify: `src/zodb_pgjsonb/storage.py:268-281`
+
+- [ ] **Step 1: Add the configure helper at module level**
+
+Locate the imports section near the top (search for `import os`).  Add (or extend) an env-driven constant block.  At the bottom of the storage.py imports block (just above `class PGJsonbStorage`), add:
+
+```python
+# ── Idle-in-transaction safety net (#118) ─────────────────────────────
+# Bound the worst-case duration of any leaked virtualxid so it doesn't
+# block CREATE INDEX CONCURRENTLY indefinitely.  Tunable via env var.
+DEFAULT_IDLE_IN_XACT_TIMEOUT_MS = 60_000
+ENV_IDLE_IN_XACT_TIMEOUT = "ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"
+
+
+def _configure_pool_conn(conn):
+    """psycopg_pool ``configure`` hook applied on every new pool conn.
+
+    Sets autocommit (required by the instance state machine) and the
+    idle_in_transaction_session_timeout safety net.
+    """
+    conn.autocommit = True
+    timeout_ms = int(
+        os.environ.get(ENV_IDLE_IN_XACT_TIMEOUT, DEFAULT_IDLE_IN_XACT_TIMEOUT_MS)
+    )
+    if timeout_ms > 0:
+        conn.execute(f"SET idle_in_transaction_session_timeout = {timeout_ms}")
+    elif timeout_ms == 0:
+        # Explicitly disabled — leave PG default (also 0).
+        conn.execute("SET idle_in_transaction_session_timeout = 0")
+```
+
+Verify `os` is imported at module top.  If not, add `import os`.
+
+- [ ] **Step 2: Replace the inline `lambda` configure with the named helper**
+
+Find the existing pool creation:
+
+```python
+        self._instance_pool = ConnectionPool(
+            dsn,
+            min_size=pool_size,
+            max_size=pool_max_size,
+            timeout=pool_timeout,
+            kwargs={"row_factory": dict_row},
+            configure=lambda conn: setattr(conn, "autocommit", True),
+            open=True,
+        )
+```
+
+Change the `configure=` line to:
+
+```python
+            configure=_configure_pool_conn,
+```
+
+(Keep the rest unchanged.)
+
+- [ ] **Step 3: Run the timeout tests**
+
+Run: `PYTHONPATH=src .venv/bin/pytest tests/test_idle_in_xact.py -v`
+Expected: all tests pass (4 from Task 3 + 3 timeout tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/zodb_pgjsonb/storage.py
+git commit -m "feat(pool): set idle_in_transaction_session_timeout on every conn (#118)"
+```
+
+---
+
+### Task 6: Full suite + changelog
+
+**Files:**
+- Modify: `CHANGES.md`
+
+- [ ] **Step 1: Run the full suite**
+
+Run: `PYTHONPATH=src .venv/bin/pytest -q`
+Expected: pre-existing baseline (5 unrelated failures permitted, but no new ones).
+
+- [ ] **Step 2: Add changelog entry**
+
+In `CHANGES.md`, find the `## Unreleased` block (under `# Changelog`).  If absent, create it directly under `# Changelog`.  Add:
+
+```markdown
+- Implement ``IStorage.afterCompletion`` on ``PGJsonbStorageInstance``
+  so the REPEATABLE READ read-snapshot transaction is committed at
+  request end (after every ``transaction.commit/abort`` and on
+  ``Connection.close``).  Previously the read tx persisted across
+  request boundaries until the connection was reused, leaving
+  ``idle in transaction`` sessions with live virtualxids that
+  blocked ``CREATE INDEX CONCURRENTLY`` for minutes-to-hours under
+  load.  Closes bluedynamics/plone-pgcatalog#118.
+
+- Set ``idle_in_transaction_session_timeout`` (default 60_000 ms,
+  env-overridable via ``ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS``) on
+  every connection from the instance pool.  Defense in depth for
+  any future leak path that bypasses ``afterCompletion`` (e.g.
+  ``SIGKILL``-ed worker, buggy plugin).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGES.md docs/superpowers/specs/2026-04-13-idle-in-xact-design.md docs/superpowers/plans/2026-04-13-idle-in-xact-zodb-pgjsonb.md
+git commit -m "docs: changelog + spec + plan for #118 read-tx fix"
+```
+
+---
+
+### Task 7: Push + open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin fix/idle-in-xact
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --repo bluedynamics/zodb-pgjsonb --base main --head fix/idle-in-xact \
+  --title "Close read txn at request end (afterCompletion) + idle-in-xact safety net (#118)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Stops \`PGJsonbStorageInstance\` leaking REPEATABLE READ transactions across requests, so they no longer block \`CREATE INDEX CONCURRENTLY\` and similar maintenance operations.
+
+- **\`afterCompletion\`** on \`PGJsonbStorageInstance\` (root-cause fix).  ZODB calls this hook after every transaction commit/abort and on \`Connection.close()\`.  Previously the class did not define it, so the hook was a silent no-op and the read tx lingered until the connection was eventually evicted.  Method is idempotent (no-op when no read tx is open) and never propagates exceptions (a killed conn is logged, not raised).
+- **\`idle_in_transaction_session_timeout = 60_000\`** on every connection the instance pool hands out — defense in depth for any future leak path (SIGKILL-ed worker, third-party plugin).  Tunable via \`ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS\` (set to \`0\` to disable).
+
+Closes bluedynamics/plone-pgcatalog#118.
+
+## Tests
+
+- 4 \`afterCompletion\` integration tests: closes-read-txn, idempotent, no-op-after-tpc-begin, safe-when-killed.
+- 1 end-to-end test: ZODB read-only transaction → \`pg_stat_activity\` shows \`state = 'idle'\` (not \`idle in transaction\`).
+- 3 idle-timeout tests: default, env override, disabled-when-zero.
+
+## Spec
+
+\`docs/superpowers/specs/2026-04-13-idle-in-xact-design.md\` — full root-cause analysis, trade-off table (Fix 1 / 2 / 3 / 4 / E), test plan.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Report PR URL.

--- a/docs/superpowers/specs/2026-04-13-idle-in-xact-design.md
+++ b/docs/superpowers/specs/2026-04-13-idle-in-xact-design.md
@@ -1,0 +1,305 @@
+# Idle-in-Transaction Read Sessions Block CIC — Design Spec
+
+**Issue:** https://github.com/bluedynamics/plone-pgcatalog/issues/118
+**Date:** 2026-04-13
+**Scope:** primarily `zodb-pgjsonb` (architectural fix), secondarily `plone-pgcatalog` (defensive cleanup)
+
+## Problem
+
+`CREATE INDEX CONCURRENTLY` (and `DROP INDEX CONCURRENTLY`,
+`REINDEX CONCURRENTLY`) on `object_state` hangs for minutes — often
+indefinitely under load — because pgcatalog read paths leave PG
+connections in `idle in transaction` state, each holding a
+`virtualxid` lock.  PostgreSQL CIC must wait for *all* existing
+virtualxids to drain before finalizing.
+
+## Verified root cause
+
+`PGJsonbStorageInstance` opens a `REPEATABLE READ` transaction in
+[`poll_invalidations()`](src/zodb_pgjsonb/instance.py) at the start of
+every Plone request and keeps it open until *one* of:
+
+1. The next `poll_invalidations()` call (commits, then re-opens).
+2. The next `tpc_begin()` call (writes — commits, then opens an
+   explicit write txn).
+3. `release()` is called.  But ZODB only calls `storage.close()`
+   (which calls `release()`) when the connection is *truly discarded*
+   from the pool — not on every `Connection.close()`.
+
+ZODB's standard hook for "the request is done, close any open
+transaction" is `IStorage.afterCompletion()`:
+
+- [Connection.py:313](.venv/lib/python3.13/site-packages/ZODB/Connection.py):
+  `if hasattr(self._storage, 'afterCompletion'): self._storage.afterCompletion()`
+- Also fires after every `transaction.commit()` / `abort()` via the
+  synchronizer ([Connection.py:737-747](.venv/lib/python3.13/site-packages/ZODB/Connection.py)).
+
+`PGJsonbStorageInstance` **does not implement** `afterCompletion()` —
+so the hook is silently a no-op.  The read txn persists across
+requests until the connection is actually evicted from the pool, which
+under steady load may be hours.
+
+A secondary contribution:
+[`plone-pgcatalog/src/plone/pgcatalog/pool.py:74-89`](sources/plone-pgcatalog/src/plone/pgcatalog/pool.py)
+calls `pool.putconn(conn)` without an explicit `commit/rollback`.  For
+the pool fallback path (tests, scripts, no-ZODB use), pool conns are
+not autocommit and any prior `SELECT` leaves an implicit txn open
+until the next user reuses the conn.  This is a much smaller leak
+(pool connections rotate, the bug only matters for the brief idle
+window) but should be fixed for symmetry.
+
+## Why CIC blocks on virtualxids
+
+PostgreSQL `CREATE INDEX CONCURRENTLY` performs three sequential
+phases.  Between phases, it `SELECT`s and *waits* for every other
+session's `virtualxid` to disappear, so it can prove no concurrent
+writer is in flight.  An `idle in transaction` session keeps its
+virtualxid alive.  Read transactions are not exempt — virtualxids do
+not distinguish read-only from read-write.
+
+A Plone instance under steady load can have many virtualxids alive at
+any moment.  CIC's wait set never empties → it waits forever.
+
+## Goal
+
+Eliminate idle-in-transaction PG sessions whose only reason to exist
+is "the previous Plone request opened a read snapshot and never
+explicitly closed it."  Reduce the worst-case duration of any
+`virtualxid` to "the active duration of one Plone request" — a
+bounded, manageable quantity.
+
+## Design
+
+### Fix 1 — implement `afterCompletion()` on `PGJsonbStorageInstance` (zodb-pgjsonb)
+
+```python
+def afterCompletion(self):
+    """ZODB hook: end any open REPEATABLE READ snapshot.
+
+    Called by ZODB after every transaction (commit or abort) and on
+    Connection.close().  Closing the read transaction at request end
+    avoids holding a virtualxid that blocks CREATE INDEX CONCURRENTLY
+    and similar maintenance operations (#118).
+    """
+    try:
+        self._end_read_txn()
+    except Exception:
+        # Never propagate from a sync hook — the connection may have
+        # been killed externally (e.g. by idle_in_transaction_session_timeout).
+        # Mark the conn dirty so the next operation rebuilds it via the pool.
+        log.warning("afterCompletion: _end_read_txn failed", exc_info=True)
+```
+
+**Properties:**
+- Idempotent: `_end_read_txn` checks `_in_read_txn` and is a no-op if
+  not in a read txn.
+- Safe at every call site:
+  - After write `tpc_finish`: `tpc_begin` already called
+    `_end_read_txn`, so `_in_read_txn=False` → no-op.
+  - After read-only request: read txn is open → COMMIT → virtualxid
+    released.
+  - After abort: same as above.
+  - On `Connection.close()`: same as above.
+- Snapshot consistency unchanged: ZODB's contract is per-transaction
+  consistency; `poll_invalidations()` always opens a fresh snapshot
+  for the next transaction anyway.
+
+**Performance impact:**
+- One extra `COMMIT` round-trip per Plone request (only when the
+  request actually opened a read txn — i.e. did at least one
+  `poll_invalidations` + load).  Localhost PG: ~0.1ms.  Network PG:
+  one RTT.  Acceptable.
+- No effect on write requests (already `_end_read_txn`'d in tpc_begin).
+
+**Risks:**
+- A storage that overrides `afterCompletion` (RelStorage-style
+  pattern) might do unexpected things on `_end_read_txn` failure.
+  Mitigation: try/except + log + don't propagate.
+
+### Fix 2 — `idle_in_transaction_session_timeout` defense in depth (zodb-pgjsonb)
+
+Even with Fix 1, leaks remain possible:
+- Crashed Zope worker (SIGKILL): no afterCompletion fires.
+- A buggy storage subclass / future plugin that bypasses the hook.
+- The pool fallback path in plone-pgcatalog (and any other consumer
+  using the same DSN).
+
+Bound the impact with a server-side timer on every PG connection
+zodb-pgjsonb opens:
+
+```python
+DEFAULT_IDLE_IN_XACT_TIMEOUT_MS = 60_000
+ENV_IDLE_IN_XACT_TIMEOUT = "ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"
+
+def _configure_conn(conn):
+    """Per-connection setup applied by the pool's `configure` hook."""
+    timeout = int(
+        os.environ.get(ENV_IDLE_IN_XACT_TIMEOUT, DEFAULT_IDLE_IN_XACT_TIMEOUT_MS)
+    )
+    if timeout > 0:
+        conn.execute(f"SET idle_in_transaction_session_timeout = {timeout}")
+```
+
+Wired via `psycopg_pool.ConnectionPool(..., configure=_configure_conn)`.
+
+**Properties:**
+- 60s default: long enough that a slow Plone request doesn't get its
+  read tx killed mid-request, short enough that a leaked tx clears
+  before CIC (which itself may have a 5-min timeout in
+  `apply_index`).
+- Override: env var.  Operator can set 0 to disable, or e.g. 30s for
+  stricter envs.
+- Applies to all conns from zodb-pgjsonb's pool — including the conns
+  plone-pgcatalog discovers via `_pool_from_storage()`.  Two birds.
+
+**Risks:**
+- A request that legitimately holds a read tx open longer than the
+  timeout — e.g. a slow third-party tool — will get killed and have
+  to retry.  60s is generous.  Document.
+
+### Fix 3 — explicit rollback before `pool.putconn` (plone-pgcatalog)
+
+In `pool.py:release_request_connection()`, replace:
+
+```python
+if conn is not None and pool is not None:
+    try:
+        if not conn.closed:
+            pool.putconn(conn)
+    except Exception:
+        log.warning("Failed to return connection to pool", exc_info=True)
+```
+
+with:
+
+```python
+if conn is not None and pool is not None:
+    try:
+        if not conn.closed:
+            with contextlib.suppress(Exception):
+                conn.rollback()  # release any implicit txn before pooling
+            pool.putconn(conn)
+    except Exception:
+        log.warning("Failed to return connection to pool", exc_info=True)
+```
+
+**Properties:**
+- Affects the fallback path only (no ZODB storage available).
+- `rollback()` on an autocommit conn or a conn with no open txn is
+  cheap and safe.
+- Defense in depth — Fix 2's timeout will eventually clean up
+  anyway, but explicit rollback is immediate.
+
+### Fix 4 (optional, separate PR) — drop-invalid-indexes UI (plone-pgcatalog)
+
+Independent of the cause-fix.  In the ZMI Catalog → Slow Queries tab:
+
+- Query `pg_index` for `NOT indisvalid` entries on `object_state`.
+- For each, render a row with name + size + age + a "Drop" button
+  that issues `DROP INDEX CONCURRENTLY IF EXISTS <name>`.
+- Refuse to drop indexes outside the `idx_os_*` namespace (mirroring
+  `drop_index`'s safety in `suggestions.py`).
+
+Self-service recovery for the failure mode that prompted this issue.
+*Out of scope for this fix bundle*; can be a follow-up PR.
+
+### Out of scope
+
+- **Background CIC job with progress reporting** (issue #118 option E).
+  Real CIC duration is bounded once Fix 1 + 2 land — no more
+  multi-hour hangs.  Adding a job worker is a substantial new
+  subsystem; defer until there's an actual signal it's needed.
+- **Maintenance-mode toggle** (issue #118 option C).  After Fix 1 +
+  2, CIC under normal load should complete in seconds (PG only waits
+  for the *currently active* virtualxids, which all clear within
+  60s).  Toggle adds operational complexity for a problem the
+  primary fixes already solve.
+
+## Trade-off analysis
+
+| Option | Fixes root cause? | Complexity | Risk | Verdict |
+|--------|-------------------|------------|------|---------|
+| **Fix 1 (afterCompletion)** | yes — virtualxid drops at request end | very low (8 LOC) | low (idempotent, try/except) | **must do** |
+| **Fix 2 (PG timeout)** | bounds worst case | low (15 LOC + env var) | low (60s is generous) | **must do** (defense in depth) |
+| **Fix 3 (explicit rollback)** | partial (fallback path only) | trivial (3 LOC) | none | **should do** |
+| Fix 4 (drop-invalid UI) | no — recovery only | medium (UI + endpoint) | low | **defer to follow-up** |
+| Option E (background job) | no — masks symptom | high (worker, queue, status) | high (new subsystem) | **out of scope** |
+
+## Test plan
+
+### Fix 1 — `afterCompletion`
+
+Integration tests in zodb-pgjsonb (require PG):
+
+1. **`test_after_completion_closes_read_txn`**: open instance, call
+   `poll_invalidations()` to start a snapshot, assert
+   `_in_read_txn` is True, call `afterCompletion()`, assert it's
+   False and the conn has no open transaction
+   (`SELECT pg_backend_pid()` from a separate conn querying
+   `pg_stat_activity` for our pid → state should be `idle`, not
+   `idle in transaction`).
+2. **`test_after_completion_idempotent`**: call twice in a row, no
+   error, second call is a no-op.
+3. **`test_after_completion_safe_when_conn_killed`**: open snapshot,
+   externally `pg_terminate_backend` the conn, call
+   `afterCompletion()`, assert no exception propagates.
+4. **`test_after_completion_no_op_after_tpc_begin`**: write txn (tpc_begin
+   already ended the read), call `afterCompletion()` — no-op.
+5. **End-to-end via ZODB**: open `ZODB.DB(storage)`, do a read-only
+   transaction, `connection.close()`, query `pg_stat_activity` for
+   our session — assert `state = 'idle'`.
+
+### Fix 2 — `idle_in_transaction_session_timeout`
+
+Integration tests:
+
+1. **`test_idle_timeout_set_on_new_conn`**: open storage, take a conn
+   from the pool, query `current_setting('idle_in_transaction_session_timeout')`
+   → `'60000'`.
+2. **`test_idle_timeout_env_override`**: set env var to `5000`,
+   re-open storage, assert setting is `'5000'`.
+3. **`test_idle_timeout_disabled_when_zero`**: env var `0` → setting
+   is `'0'` (PG's "disabled" value).
+
+### Fix 3 — explicit rollback
+
+Unit test in plone-pgcatalog (mock conn):
+
+1. **`test_release_request_connection_rolls_back`**: mock conn, call
+   `release_request_connection()`, assert `conn.rollback()` was
+   called before `pool.putconn(conn)`.
+
+## Operator guidance (CHANGES.md + docs)
+
+After deploy:
+- No action required — fixes are transparent.
+- If a deployment routinely sees CIC stalls before the fix, document
+  the pre-fix workaround:
+  ```sql
+  SELECT pg_terminate_backend(pid)
+  FROM pg_stat_activity
+  WHERE datname = current_database()
+    AND state = 'idle in transaction'
+    AND pid <> pg_backend_pid();
+  ```
+- Tunable: `ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS` (default 60000).
+  Set to `0` to disable the safety net entirely.
+
+## PR split
+
+- **PR1 (zodb-pgjsonb):** Fix 1 + Fix 2.  Co-located because Fix 2
+  is defense-in-depth for Fix 1 — landing them separately leaves a
+  weird intermediate state.
+- **PR2 (plone-pgcatalog):** Fix 3.  Independent, small, can land
+  in either order.
+- **(future) PR3 (plone-pgcatalog):** Fix 4 drop-invalid-indexes UI.
+  Operator quality-of-life; not a regression.
+
+## Risk summary
+
+| Risk | Mitigation |
+|------|------------|
+| `afterCompletion` raises and breaks ZODB pool return | try/except + log |
+| 60s timeout kills a slow legitimate request | env-var override; document tunable |
+| Snapshot continuity expected by some caller | ZODB only guarantees per-txn; `poll_invalidations` re-opens snapshot |
+| Tests can't observe `pg_stat_activity` reliably (CI noise) | use deterministic checks: query backend's own setting, `_in_read_txn` flag, conn `pgconn.transaction_status` |

--- a/src/zodb_pgjsonb/instance.py
+++ b/src/zodb_pgjsonb/instance.py
@@ -110,6 +110,27 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
         if os.path.exists(self._blob_temp_dir):
             shutil.rmtree(self._blob_temp_dir, ignore_errors=True)
 
+    def afterCompletion(self):
+        """ZODB hook: end any open REPEATABLE READ snapshot.
+
+        Called by ZODB after every transaction commit/abort and on
+        ``Connection.close()`` (see ``ZODB.Connection.close``).
+        Closing the read transaction at request end avoids holding a
+        ``virtualxid`` that blocks ``CREATE INDEX CONCURRENTLY`` and
+        similar maintenance operations (#118).
+
+        Idempotent: ``_end_read_txn`` short-circuits when no read tx
+        is open (e.g. right after a write transaction's ``tpc_begin``
+        already ended it).  Never raises — the connection may have
+        been killed by an external operator or by
+        ``idle_in_transaction_session_timeout``; in that case we just
+        log and let the next operation rebuild via the pool.
+        """
+        try:
+            self._end_read_txn()
+        except Exception:
+            logger.warning("afterCompletion: _end_read_txn failed", exc_info=True)
+
     def _end_read_txn(self):
         """End the current REPEATABLE READ snapshot transaction, if any."""
         if self._in_read_txn:

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -67,6 +67,27 @@ logger = logging.getLogger(__name__)
 _VALID_SQL_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 
+# ── Idle-in-transaction safety net (#118) ─────────────────────────────
+# Bound the worst-case duration of any leaked virtualxid so it doesn't
+# block CREATE INDEX CONCURRENTLY indefinitely.  Tunable via env var.
+DEFAULT_IDLE_IN_XACT_TIMEOUT_MS = 60_000
+ENV_IDLE_IN_XACT_TIMEOUT = "ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"
+
+
+def _configure_pool_conn(conn):
+    """psycopg_pool ``configure`` hook applied on every new pool conn.
+
+    Sets autocommit (required by the instance state machine) and the
+    idle_in_transaction_session_timeout safety net.  ``0`` disables
+    the timeout (matches PG default).
+    """
+    conn.autocommit = True
+    timeout_ms = int(
+        os.environ.get(ENV_IDLE_IN_XACT_TIMEOUT, DEFAULT_IDLE_IN_XACT_TIMEOUT_MS)
+    )
+    conn.execute(f"SET idle_in_transaction_session_timeout = {timeout_ms}")
+
+
 @dataclasses.dataclass
 class ExtraColumn:
     """Declares an extra column for object_state written by a state processor.
@@ -275,7 +296,7 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
             max_size=pool_max_size,
             timeout=pool_timeout,
             kwargs={"row_factory": dict_row},
-            configure=lambda conn: setattr(conn, "autocommit", True),
+            configure=_configure_pool_conn,
             open=True,
         )
         logger.debug("Connection pool ready")

--- a/tests/test_idle_in_xact.py
+++ b/tests/test_idle_in_xact.py
@@ -5,6 +5,8 @@ don't accumulate and block CREATE INDEX CONCURRENTLY.
 from tests.conftest import clean_db
 from tests.conftest import DSN
 
+import contextlib
+import psycopg
 import pytest
 
 
@@ -44,5 +46,144 @@ def test_after_completion_closes_read_txn():
             assert instance._in_read_txn is False
         finally:
             instance.release()
+    finally:
+        storage.close()
+
+
+def test_after_completion_idempotent():
+    """Calling afterCompletion twice in a row is safe."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        instance = storage.new_instance()
+        try:
+            instance.poll_invalidations()
+            instance.afterCompletion()
+            # Second call: no-op, no error
+            instance.afterCompletion()
+            assert instance._in_read_txn is False
+        finally:
+            instance.release()
+    finally:
+        storage.close()
+
+
+def test_after_completion_no_op_after_tpc_begin():
+    """tpc_begin already ends the read tx — afterCompletion is a no-op then."""
+    from persistent.mapping import PersistentMapping
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    import transaction as txn
+    import ZODB
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        db = ZODB.DB(storage)
+        try:
+            conn = db.open()
+            root = conn.root()
+            root["x"] = PersistentMapping({"k": "v"})
+            txn.commit()
+            instance = conn._storage
+            # After commit, read tx should be closed (commit path ends it)
+            instance.afterCompletion()
+            assert instance._in_read_txn is False
+            conn.close()
+        finally:
+            db.close()
+    finally:
+        storage.close()
+
+
+def test_after_completion_safe_when_conn_killed():
+    """If the conn is externally terminated, afterCompletion must not raise."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        instance = storage.new_instance()
+        try:
+            instance.poll_invalidations()
+            assert instance._in_read_txn is True
+
+            # Kill the backend from a separate session
+            pid = instance._conn.info.backend_pid
+            killer = psycopg.connect(DSN)
+            try:
+                killer.execute("SELECT pg_terminate_backend(%s)", (pid,))
+                killer.commit()
+            finally:
+                killer.close()
+
+            # afterCompletion must swallow the resulting connection error
+            instance.afterCompletion()  # must not raise
+        finally:
+            # Force release without raising — conn is dead
+            with contextlib.suppress(Exception):
+                instance.release()
+    finally:
+        with contextlib.suppress(Exception):
+            storage.close()
+
+
+def test_zodb_connection_close_releases_virtualxid():
+    """End-to-end: closing a read-only ZODB connection releases its virtualxid.
+
+    Without afterCompletion, the storage instance's PG connection would
+    stay 'idle in transaction' — the connection sits in the ZODB pool
+    holding a virtualxid that blocks CREATE INDEX CONCURRENTLY.
+
+    Note: mid-request transaction.abort() / commit() also fires
+    afterCompletion, but ZODB.Connection.afterCompletion immediately
+    calls newTransaction() → poll_invalidations() which re-opens the
+    read tx for the next implicit transaction.  The win is at
+    Connection.close() (pool return / request end), where no
+    newTransaction follows.
+    """
+    from psycopg.rows import dict_row
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    import transaction as txn
+    import ZODB
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        db = ZODB.DB(storage)
+        try:
+            conn = db.open()
+            instance = conn._storage
+            _ = conn.root()  # triggers poll_invalidations + a load
+            assert instance._in_read_txn is True
+
+            pid = instance._conn.info.backend_pid
+
+            # End the implicit transaction first (release synchronizer
+            # references), then close — Connection.close() invokes
+            # storage.afterCompletion() WITHOUT a follow-up
+            # newTransaction, which is the lifecycle moment that
+            # matters for the issue.
+            txn.abort()
+            conn.close()
+
+            # The instance's _in_read_txn flag and PG state are now
+            # what new requests against this same pooled connection
+            # will see.  Verify both.
+            assert instance._in_read_txn is False
+
+            monitor = psycopg.connect(DSN, row_factory=dict_row)
+            try:
+                state, _age = _backend_state(monitor, pid)
+                # 'idle' = transaction closed.  Anything else (esp.
+                # 'idle in transaction') means the leak is back.
+                assert state == "idle", f"Expected idle, got {state!r}"
+            finally:
+                monitor.close()
+        finally:
+            db.close()
     finally:
         storage.close()

--- a/tests/test_idle_in_xact.py
+++ b/tests/test_idle_in_xact.py
@@ -189,6 +189,24 @@ def test_zodb_connection_close_releases_virtualxid():
         storage.close()
 
 
+def _read_idle_timeout_ms(storage):
+    """Return idle_in_transaction_session_timeout as an int in ms.
+
+    PostgreSQL canonicalizes the value on read — `60000` may come back
+    as `'1min'`, `5000` as `'5s'`, etc.  Use pg_settings to get the
+    underlying numeric in the configured unit.
+    """
+    with storage._instance_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT setting::int AS v, unit FROM pg_settings "
+            "WHERE name = 'idle_in_transaction_session_timeout'"
+        )
+        row = cur.fetchone()
+    # unit is 'ms' for this setting per PG docs
+    assert row["unit"] == "ms"
+    return row["v"]
+
+
 def test_idle_timeout_set_on_pool_conn():
     """Every conn from the instance pool has idle_in_transaction_session_timeout set."""
     from zodb_pgjsonb.storage import PGJsonbStorage
@@ -196,13 +214,7 @@ def test_idle_timeout_set_on_pool_conn():
     clean_db()
     storage = PGJsonbStorage(DSN, cache_warm_pct=0)
     try:
-        with storage._instance_pool.connection() as conn, conn.cursor() as cur:
-            cur.execute(
-                "SELECT current_setting('idle_in_transaction_session_timeout') AS v"
-            )
-            row = cur.fetchone()
-        # Default 60_000 ms.  PG returns the numeric as-is when set numerically.
-        assert row["v"] in ("60000", "1min")
+        assert _read_idle_timeout_ms(storage) == 60_000
     finally:
         storage.close()
 
@@ -219,12 +231,7 @@ def test_idle_timeout_env_override():
     try:
         storage = PGJsonbStorage(DSN, cache_warm_pct=0)
         try:
-            with storage._instance_pool.connection() as conn, conn.cursor() as cur:
-                cur.execute(
-                    "SELECT current_setting('idle_in_transaction_session_timeout') AS v"
-                )
-                row = cur.fetchone()
-            assert row["v"] == "5000"
+            assert _read_idle_timeout_ms(storage) == 5000
         finally:
             storage.close()
     finally:
@@ -246,12 +253,7 @@ def test_idle_timeout_disabled_when_zero():
     try:
         storage = PGJsonbStorage(DSN, cache_warm_pct=0)
         try:
-            with storage._instance_pool.connection() as conn, conn.cursor() as cur:
-                cur.execute(
-                    "SELECT current_setting('idle_in_transaction_session_timeout') AS v"
-                )
-                row = cur.fetchone()
-            assert row["v"] == "0"
+            assert _read_idle_timeout_ms(storage) == 0
         finally:
             storage.close()
     finally:

--- a/tests/test_idle_in_xact.py
+++ b/tests/test_idle_in_xact.py
@@ -1,0 +1,48 @@
+"""Tests for #118: read tx must be closed at request end so virtualxids
+don't accumulate and block CREATE INDEX CONCURRENTLY.
+"""
+
+from tests.conftest import clean_db
+from tests.conftest import DSN
+
+import pytest
+
+
+pytestmark = pytest.mark.db
+
+
+def _backend_state(monitor_conn, pid):
+    """Return (state, xact_age_seconds) for a backend pid via a separate conn."""
+    with monitor_conn.cursor() as cur:
+        cur.execute(
+            "SELECT state, "
+            "EXTRACT(EPOCH FROM (now() - xact_start)) AS xact_age "
+            "FROM pg_stat_activity WHERE pid = %s",
+            (pid,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return (None, None)
+        return (row["state"], row["xact_age"])
+
+
+def test_after_completion_closes_read_txn():
+    """afterCompletion() must end the REPEATABLE READ snapshot."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        instance = storage.new_instance()
+        try:
+            # poll_invalidations opens the read txn
+            instance.poll_invalidations()
+            assert instance._in_read_txn is True
+
+            # afterCompletion must close it
+            instance.afterCompletion()
+            assert instance._in_read_txn is False
+        finally:
+            instance.release()
+    finally:
+        storage.close()

--- a/tests/test_idle_in_xact.py
+++ b/tests/test_idle_in_xact.py
@@ -187,3 +187,75 @@ def test_zodb_connection_close_releases_virtualxid():
             db.close()
     finally:
         storage.close()
+
+
+def test_idle_timeout_set_on_pool_conn():
+    """Every conn from the instance pool has idle_in_transaction_session_timeout set."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        with storage._instance_pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT current_setting('idle_in_transaction_session_timeout') AS v"
+            )
+            row = cur.fetchone()
+        # Default 60_000 ms.  PG returns the numeric as-is when set numerically.
+        assert row["v"] in ("60000", "1min")
+    finally:
+        storage.close()
+
+
+def test_idle_timeout_env_override():
+    """ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS env var overrides default."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    import os
+
+    clean_db()
+    old = os.environ.get("ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS")
+    os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"] = "5000"
+    try:
+        storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+        try:
+            with storage._instance_pool.connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT current_setting('idle_in_transaction_session_timeout') AS v"
+                )
+                row = cur.fetchone()
+            assert row["v"] == "5000"
+        finally:
+            storage.close()
+    finally:
+        if old is None:
+            del os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"]
+        else:
+            os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"] = old
+
+
+def test_idle_timeout_disabled_when_zero():
+    """Setting the env var to 0 disables the timeout (PG default)."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    import os
+
+    clean_db()
+    old = os.environ.get("ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS")
+    os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"] = "0"
+    try:
+        storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+        try:
+            with storage._instance_pool.connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT current_setting('idle_in_transaction_session_timeout') AS v"
+                )
+                row = cur.fetchone()
+            assert row["v"] == "0"
+        finally:
+            storage.close()
+    finally:
+        if old is None:
+            del os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"]
+        else:
+            os.environ["ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS"] = old


### PR DESCRIPTION
## Summary

Stops \`PGJsonbStorageInstance\` leaking REPEATABLE READ transactions across requests, so they no longer block \`CREATE INDEX CONCURRENTLY\` and similar maintenance operations.

- **\`afterCompletion\`** on \`PGJsonbStorageInstance\` (root-cause fix). ZODB calls this hook on every transaction commit/abort and on \`Connection.close()\`. Previously the class did not define it, so the hook was a silent no-op and the read tx lingered until the connection was eventually evicted. Method is idempotent (no-op when no read tx is open) and never propagates exceptions (a killed conn is logged, not raised).
- **\`idle_in_transaction_session_timeout = 60_000\`** on every connection the instance pool hands out — defense in depth for any future leak path (SIGKILL-ed worker, third-party plugin). Tunable via \`ZODB_PGJSONB_IDLE_IN_XACT_TIMEOUT_MS\` (set to \`0\` to disable).

Closes bluedynamics/plone-pgcatalog#118.

## Why mid-request transactions don't appear to benefit

ZODB's \`Connection.afterCompletion\` calls \`storage.afterCompletion()\` then immediately calls \`newTransaction()\` → \`poll_invalidations()\` for the next implicit transaction — which re-opens the read tx. So intra-request, the read tx stays effectively open. The actual win is at \`Connection.close()\` (pool return / request end), where there's no follow-up \`newTransaction\`. End-to-end test pins this down via \`pg_stat_activity\` showing \`state = 'idle'\` after close.

## Tests

- 4 \`afterCompletion\` integration tests: closes-read-txn, idempotent, no-op-after-tpc-begin, safe-when-killed.
- 1 end-to-end test: ZODB read-only transaction → \`pg_stat_activity\` shows \`state = 'idle'\` (not \`idle in transaction\`).
- 3 idle-timeout tests: default 60_000 ms, env override, disabled-when-zero.

Full suite: 456 passed (was 449), no regressions.

## Spec

\`docs/superpowers/specs/2026-04-13-idle-in-xact-design.md\` — full root-cause analysis, trade-off table (Fix 1 / 2 / 3 / 4 / E), test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)