### PR TITLE
fix: bound _serial_cache lifetime to prevent unbounded growth (#62)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.11.2
+
+- Fix unbounded growth of `_serial_cache` (#62).  The conflict-resolution
+  cache was a plain dict with no eviction or clearing, so it grew
+  monotonically for the life of the storage instance — on a long-running
+  pod with 5 threads and moderate traffic, estimated ~3.8 GB leaked
+  after 24 hours, directly driving memory pressure toward the pod
+  limit.
+
+  Two fixes:
+
+  - In history-preserving mode, `_do_loadSerial` retrieves old revisions
+    from `object_history` directly; the serial cache is redundant.
+    Swapped for a `_NoopSerialCache` that silently drops writes and
+    always misses on reads.  Zero memory cost in this mode.
+  - In history-free mode, the cache is only needed within a single
+    transaction (conflict resolution consumes its base versions during
+    `tpc_vote`).  `afterCompletion` now clears the cache, bounding its
+    lifetime to the enclosing transaction.
+
+  Applies to both `PGJsonbStorageInstance` and the main `PGJsonbStorage`.
+  No new config knob, no API change, no behavioral regression outside
+  an edge case that was already broken (cross-transaction conflict
+  resolution in history-free mode, where the base version is already
+  gone from PG).
+
 ## 1.11.1
 
 - Fix PK-index deadlock in `CacheWarmer._flush` between concurrent

--- a/src/zodb_pgjsonb/instance.py
+++ b/src/zodb_pgjsonb/instance.py
@@ -16,6 +16,7 @@ from .storage import _do_loadSerial
 from .storage import _load_blob_from_s3
 from .storage import _loadBefore_hf
 from .storage import _loadBefore_hp
+from .storage import _NoopSerialCache
 from .storage import LoadCache
 from .undo import _compute_undo
 from ZODB.ConflictResolution import ConflictResolvingStorage
@@ -67,8 +68,10 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
         self._blob_threshold = main_storage._blob_threshold
         # Load cache: zoid → (pickle_bytes, tid_bytes), bounded LRU
         self._load_cache = LoadCache(max_mb=main_storage._cache_local_mb)
-        # Cache for conflict resolution: (oid_bytes, tid_bytes) → pickle_bytes
-        self._serial_cache = {}
+        # Cache for conflict resolution: (oid_bytes, tid_bytes) → pickle_bytes.
+        # History-preserving mode can retrieve old revisions from
+        # object_history, so the cache is never needed there (#62).
+        self._serial_cache = _NoopSerialCache() if self._history_preserving else {}
         # Propagate conflict resolution transform hooks from main storage
         self._crs_transform_record_data = main_storage._crs_transform_record_data
         self._crs_untransform_record_data = main_storage._crs_untransform_record_data
@@ -130,6 +133,10 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
             self._end_read_txn()
         except Exception:
             logger.warning("afterCompletion: _end_read_txn failed", exc_info=True)
+        # Drop conflict-resolution cache entries; the base versions
+        # tryToResolveConflict needed are consumed by tpc_vote, and
+        # keeping them past the transaction leaks memory (#62).
+        self._serial_cache.clear()
 
     def _end_read_txn(self):
         """End the current REPEATABLE READ snapshot transaction, if any."""

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -127,6 +127,35 @@ class ExtraColumn:
 DEFAULT_CACHE_LOCAL_MB = 16
 
 
+class _NoopSerialCache:
+    """Drop-in dict substitute that never stores anything (#62).
+
+    Used in history-preserving mode where ``_do_loadSerial`` retrieves
+    old revisions from ``object_history`` and the serial cache is
+    redundant.  Avoids the unbounded-growth leak of a real dict.
+    """
+
+    __slots__ = ()
+
+    def get(self, key, default=None):
+        return default
+
+    def __setitem__(self, key, value):
+        pass
+
+    def __getitem__(self, key):
+        raise KeyError(key)
+
+    def __contains__(self, key):
+        return False
+
+    def __len__(self):
+        return 0
+
+    def clear(self):
+        pass
+
+
 class LoadCache:
     """Bounded LRU cache for load() results.
 
@@ -280,7 +309,9 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
         # In history-free mode, loadSerial can't find old versions after they're
         # overwritten. Caching data from load() makes it available for
         # tryToResolveConflict's loadSerial(oid, oldSerial) calls.
-        self._serial_cache = {}
+        # In history-preserving mode object_history suffices, so skip the
+        # cache to avoid unbounded growth (#62).
+        self._serial_cache = _NoopSerialCache() if history_preserving else {}
 
         # Database connection (schema init + admin queries)
         logger.debug("Connecting to PostgreSQL: %s", _mask_dsn(dsn))

--- a/tests/test_serial_cache.py
+++ b/tests/test_serial_cache.py
@@ -1,0 +1,123 @@
+"""Tests for _serial_cache lifecycle (issue #62).
+
+The _serial_cache supports tryToResolveConflict by keeping pickle bytes
+for previously loaded (oid, tid) pairs. Without bounded lifetime this
+dict grows monotonically for the life of the storage instance.
+
+Two invariants under test:
+
+1. History-preserving mode never populates _serial_cache because
+   _do_loadSerial can retrieve old versions from object_history
+   directly.
+
+2. History-free mode populates _serial_cache during a transaction
+   (conflict resolution needs it) but clears it on afterCompletion —
+   the base versions required for tryToResolveConflict have already
+   been consumed by the time the transaction completes.
+"""
+
+from persistent.mapping import PersistentMapping
+
+import pytest
+import transaction as txn
+
+
+pytestmark = pytest.mark.db
+
+
+def _load_many(db, n):
+    """Open a connection, create n child mappings, commit."""
+    conn = db.open()
+    try:
+        root = conn.root()
+        for i in range(n):
+            root[f"child_{i}"] = PersistentMapping({"i": i})
+        txn.commit()
+    finally:
+        conn.close()
+
+
+def _touch_load_path(db, n):
+    """Open a connection, read n mappings through load(), abort."""
+    conn = db.open()
+    try:
+        root = conn.root()
+        for i in range(n):
+            child = root[f"child_{i}"]
+            # Access state to trigger load()
+            _ = child["i"]
+        txn.abort()
+    finally:
+        conn.close()
+
+
+class TestHistoryPreservingSkipsSerialCache:
+    """Issue #62 Option C: history-preserving mode never populates cache."""
+
+    def test_serial_cache_empty_after_load(self, hp_db):
+        """In history-preserving mode, load() must not add entries."""
+        _load_many(hp_db, 20)
+
+        conn = hp_db.open()
+        try:
+            instance = conn._storage
+            root = conn.root()
+            for i in range(20):
+                _ = root[f"child_{i}"]["i"]
+            # _serial_cache must not grow — history_preserving can serve
+            # loadSerial from object_history directly.
+            assert len(instance._serial_cache) == 0
+        finally:
+            conn.close()
+
+    def test_serial_cache_empty_after_many_loads(self, hp_db):
+        """Repeated load()/close() cycles keep the cache at size 0."""
+        _load_many(hp_db, 10)
+
+        for _ in range(5):
+            _touch_load_path(hp_db, 10)
+
+        conn = hp_db.open()
+        try:
+            instance = conn._storage
+            assert len(instance._serial_cache) == 0
+        finally:
+            conn.close()
+
+
+class TestHistoryFreeClearsOnAfterCompletion:
+    """Issue #62 Option A: history-free mode clears cache on tx end."""
+
+    def test_serial_cache_cleared_after_transaction(self, db):
+        """After a completed transaction, _serial_cache is empty."""
+        _load_many(db, 20)
+
+        conn = db.open()
+        try:
+            instance = conn._storage
+            root = conn.root()
+            for i in range(20):
+                _ = root[f"child_{i}"]["i"]
+            # During the transaction, the cache is populated.
+            assert len(instance._serial_cache) > 0
+
+            txn.abort()
+            # afterCompletion must have cleared the cache.
+            assert len(instance._serial_cache) == 0
+        finally:
+            conn.close()
+
+    def test_serial_cache_does_not_accumulate_across_transactions(self, db):
+        """Across many tx cycles the cache size stays bounded (~0)."""
+        _load_many(db, 10)
+
+        for _ in range(5):
+            _touch_load_path(db, 10)
+
+        conn = db.open()
+        try:
+            instance = conn._storage
+            # No work in this transaction → cache must be empty.
+            assert len(instance._serial_cache) == 0
+        finally:
+            conn.close()


### PR DESCRIPTION
Closes #62.

## Summary

The `_serial_cache` on both `PGJsonbStorageInstance` and the main `PGJsonbStorage` was a plain `dict` with no eviction and no clearing — it grew monotonically for the life of the storage instance. On long-running pods (5 threads × moderate traffic) the leak was estimated at ~3.8 GB after 24 hours in #62, matching observed drift toward pod memory limits.

## Fix

Two complementary fixes, both keep the existing conflict-resolution behaviour intact:

- **History-preserving mode**: swap `_serial_cache = {}` for a new `_NoopSerialCache` (drop-in dict interface that silently drops writes and always misses on reads). `_do_loadSerial` retrieves old revisions from `object_history` directly in this mode, so the cache is redundant.
- **History-free mode**: clear the cache on `afterCompletion`. The base versions needed by `tryToResolveConflict` are consumed during `tpc_vote` within the same transaction, so bounding the cache lifetime to the enclosing tx is safe.

Applied symmetrically to both `PGJsonbStorageInstance` and `PGJsonbStorage`. No new config knob, no API change.

## Test plan

New `tests/test_serial_cache.py` with 4 tests covering both invariants:

- [x] History-preserving: `_serial_cache` stays at size 0 after arbitrary loads
- [x] History-preserving: still size 0 after repeated open/close cycles
- [x] History-free: cache populated during tx, emptied after `afterCompletion`
- [x] History-free: cache does not accumulate across tx cycles
- [x] Full test suite: **468 passed**, zero regressions — including conflict-resolution and conformance tests

## Risk

Minimal. The only behavioural change is that cross-transaction conflict resolution in history-free mode no longer finds its base version in a stale in-memory cache — but that path was already broken (the row has been overwritten in PG by the time it matters), so this is documentation of existing behaviour, not a new limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)