### PR TITLE
feat(warmer): herd mitigation for rolling deploys (#59)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 1.13.0 (unreleased)
+
+### Features
+
+- **Cache warmer herd mitigation** (#59).  Rolling Kubernetes deploys
+  used to multiply DB primary CPU by the replica count for the warmer
+  startup window, because every pod independently fired its full set
+  of warmup `SELECT`s simultaneously.  Four composable behaviors fix
+  this, all wired through six new ZConfig keys:
+
+  - `cache-warm-delay` (default 15s): baseline sleep before warmer
+    starts. Moves the warmer out of the pod's own cold-start window
+    (Plone import, plone.pgcatalog schema check, ANALYZE chatter).
+  - `cache-warm-jitter` (default 30s): additional `random(0, jitter)`
+    sleep on top.  Spreads arrival times across pods.
+  - `cache-warm-concurrency` (default 2): maximum number of pods
+    warming in parallel, cluster-wide.  Enforced via a session-level
+    PostgreSQL advisory lock semaphore (same pattern as the existing
+    startup-DDL lock).  Pods that miss a slot retry with jittered
+    backoff until `cache-warm-wait-max` expires.
+  - `cache-warm-wait-max` (default 300s): retry cap before giving up
+    and skipping warmup (logged as WARNING).
+  - `cache-warm-batch-size` (default 500): zoids per `SELECT` batch.
+  - `cache-warm-batch-pause` (default 0.5s): sleep between batches.
+    Lowers per-pod peak qps.
+
+  **Observable behavior change:** warmer queries are now delayed by
+  ~15–45s post-startup (delay + jitter), not immediate.  To restore
+  pre-1.13 behavior, set `cache-warm-delay=0`, `cache-warm-jitter=0`,
+  `cache-warm-batch-pause=0`, `cache-warm-concurrency=9999`.
+
+  **Last-pod latency:** for a 6-pod fleet with default settings, the
+  last pod has a warm L2 cache approximately 45s after the deploy
+  window.  All pods serve traffic from T+0; this is the time-to-warm,
+  not the time-to-ready.
+
+  Design: [docs/superpowers/specs/2026-05-29-cache-warmer-herd-mitigation-design.md](docs/superpowers/specs/2026-05-29-cache-warmer-herd-mitigation-design.md).
+
 ## 1.12.0
 
 ### Features

--- a/docs/superpowers/plans/2026-05-29-cache-warmer-herd-mitigation.md
+++ b/docs/superpowers/plans/2026-05-29-cache-warmer-herd-mitigation.md
@@ -1,0 +1,1881 @@
+# Cache Warmer Herd Mitigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the cluster-wide cache-warmer thundering herd on rolling Kubernetes deploys (issue #59) by adding per-pod delay + jitter (A2+A1), paced batched warmup (A3), and a PG-advisory-lock semaphore that caps cluster-wide concurrent warmers (B2b).
+
+**Architecture:** All new behavior lives inside `CacheWarmer.warm()` in `src/zodb_pgjsonb/cache_warmer.py`. Six new ZConfig keys (`cache-warm-delay`, `-jitter`, `-concurrency`, `-wait-max`, `-batch-size`, `-batch-pause`) flow through `config.py` → `PGJsonbStorage.__init__` → `CacheWarmer.__init__`. The semaphore reuses the session-level `pg_advisory_lock` pattern from `src/zodb_pgjsonb/startup_locks.py`, opening a dedicated `psycopg.connect` for the warmer's lock so a pod crash auto-releases the slot.
+
+**Tech Stack:** Python 3.11+, psycopg 3, ZODB, ZConfig, pytest, `uv` for env management. Tests use `localhost:5433` PostgreSQL (see `tests/conftest.py:DSN`).
+
+**Spec:** [docs/superpowers/specs/2026-05-29-cache-warmer-herd-mitigation-design.md](../specs/2026-05-29-cache-warmer-herd-mitigation-design.md)
+
+**Default-value convention:**
+
+- `CacheWarmer.__init__` defaults are **off** (`delay=0`, `jitter=0`, `concurrency=0`, `batch_pause=0`) — preserves backward-compat for existing direct-instantiation tests.
+- `PGJsonbStorage.__init__` defaults are the **production** values (`delay=15`, `jitter=30`, `concurrency=2`, `wait_max=300`, `batch_size=500`, `batch_pause=0.5`) — actual deployments get the new behavior automatically.
+- ZConfig keys default to the same production values, exposed for operator override.
+
+**Lock keyspace constants** (defined in `cache_warmer.py`):
+
+```python
+WARMER_LOCK_NS = 0x5A4442    # shared "ZDB" namespace (matches startup_locks.py)
+WARMER_SLOT_BASE = 100       # slot keys are WARMER_SLOT_BASE + i for i in 1..concurrency
+```
+
+---
+
+## File Structure
+
+**Modified files:**
+
+- `src/zodb_pgjsonb/cache_warmer.py` — extend `CacheWarmer.__init__` with six new parameters; add `_acquire_slot`, `_release_slot`, `_try_acquire_slot_once` helpers; rewrite `warm()` to use delay-jitter-acquire-paced-release flow.
+- `src/zodb_pgjsonb/storage.py` — extend `PGJsonbStorage.__init__` signature with the six new parameters (production defaults); forward to `CacheWarmer(...)`.
+- `src/zodb_pgjsonb/config.py` — extend the kwargs dict assembled in `PGJsonbStorageFactory.open()` to include the six new ZConfig keys.
+- `src/zodb_pgjsonb/component.xml` — add six new `<key>` elements with descriptions and defaults.
+- `tests/test_cache_warmer.py` — add new test classes for delay/jitter, batching, slot acquisition, retry loop, release, error handling; add integration tests under `TestCacheWarmerDB`.
+- `CHANGES.md` — add 1.13.0 (or 1.12.2) entry under "Features"/"Fixes" describing the six new knobs, defaults, observable behavior changes, and a pointer back to issue #59.
+
+**Created files:** none. All new code lives inside existing files. No new module.
+
+---
+
+## Task 1: Extend `CacheWarmer.__init__` with six new parameters (off defaults, no behavior change yet)
+
+**Files:**
+
+- Modify: `src/zodb_pgjsonb/cache_warmer.py:39-60` (`CacheWarmer.__init__`)
+- Test: `tests/test_cache_warmer.py` (new test method in `TestCacheWarmerRecord` or a new mini-class)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cache_warmer.py`, immediately after the `TestCacheWarmerRecord` class:
+
+```python
+class TestCacheWarmerNewKwargs:
+    """Confirms the six herd-mitigation kwargs are accepted and stored
+    on the instance with their defaults (off)."""
+
+    def test_defaults_are_off(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+        )
+        assert w._delay == 0
+        assert w._jitter == 0
+        assert w._concurrency == 0
+        assert w._wait_max == 300
+        assert w._batch_size == 500
+        assert w._batch_pause == 0.0
+        assert w._dsn is None
+
+    def test_kwargs_override(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=foo",
+            delay=15,
+            jitter=30,
+            concurrency=2,
+            wait_max=120,
+            batch_size=250,
+            batch_pause=0.25,
+        )
+        assert w._delay == 15
+        assert w._jitter == 30
+        assert w._concurrency == 2
+        assert w._wait_max == 120
+        assert w._batch_size == 250
+        assert w._batch_pause == 0.25
+        assert w._dsn == "dbname=foo"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerNewKwargs -v`
+Expected: FAIL — `AttributeError: 'CacheWarmer' object has no attribute '_delay'` (or `TypeError: __init__() got an unexpected keyword argument 'dsn'`).
+
+- [ ] **Step 3: Extend `CacheWarmer.__init__`**
+
+Modify `src/zodb_pgjsonb/cache_warmer.py` — replace the existing `__init__` (lines 39-60) with:
+
+```python
+    def __init__(
+        self,
+        conn,
+        target_count,
+        shared_cache,
+        load_current_tid_fn,
+        dsn=None,
+        decay=0.8,
+        flush_interval=1000,
+        delay=0,
+        jitter=0,
+        concurrency=0,
+        wait_max=300,
+        batch_size=500,
+        batch_pause=0.0,
+    ):
+        self.recording = target_count > 0
+        self._recorded = set()
+        self._pending = set()
+        self._target_count = target_count
+        self._flush_interval = flush_interval
+        self._decayed = False
+        self._decay = decay
+
+        # Shared cache to populate at warm time (#63)
+        self._shared_cache = shared_cache
+        self._load_current_tid_fn = load_current_tid_fn
+
+        self._conn = conn
+
+        # Herd-mitigation knobs (#59).  CacheWarmer defaults are off
+        # so direct instantiation in tests preserves prior behavior;
+        # PGJsonbStorage / ZConfig set the production defaults.
+        self._dsn = dsn
+        self._delay = delay
+        self._jitter = jitter
+        self._concurrency = concurrency
+        self._wait_max = wait_max
+        self._batch_size = batch_size
+        self._batch_pause = batch_pause
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerNewKwargs -v`
+Expected: PASS (both methods).
+
+- [ ] **Step 5: Run the full warmer test suite to confirm no regression**
+
+Run: `uv run pytest tests/test_cache_warmer.py -v`
+Expected: All pre-existing tests still pass. New `TestCacheWarmerNewKwargs` tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/zodb_pgjsonb/cache_warmer.py tests/test_cache_warmer.py
+git commit -m "feat(warmer): add six herd-mitigation kwargs (off defaults) (#59)"
+```
+
+---
+
+## Task 2: A2 + A1 — baseline delay + jitter sleep at start of `warm()`
+
+**Files:**
+
+- Modify: `src/zodb_pgjsonb/cache_warmer.py:125-145` (top of `warm()`)
+- Modify: `src/zodb_pgjsonb/cache_warmer.py` imports
+- Test: `tests/test_cache_warmer.py` (extend `TestCacheWarmerWarm`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cache_warmer.py` inside `TestCacheWarmerWarm`:
+
+```python
+    def test_warm_sleeps_delay_plus_jitter(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            delay=15,
+            jitter=30,
+        )
+
+        def loader(oids):
+            return {oid: (b"data-" + oid, p64(50)) for oid in oids}
+
+        with mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep, \
+             mock.patch(
+                 "zodb_pgjsonb.cache_warmer.random.uniform",
+                 return_value=7.0,
+             ):
+            w.warm(loader)
+
+        # First sleep call should be delay + uniform(0, jitter) = 15 + 7 = 22
+        assert mock_sleep.call_args_list[0] == mock.call(22.0)
+
+    def test_warm_no_sleep_when_disabled(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            delay=0,
+            jitter=0,
+        )
+
+        def loader(oids):
+            return {oid: (b"data-" + oid, p64(50)) for oid in oids}
+
+        with mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep:
+            w.warm(loader)
+
+        # When both delay and jitter are zero, no initial sleep call.
+        # (Subsequent calls from batching may exist; check no call with > 0.)
+        for c in mock_sleep.call_args_list:
+            assert c.args[0] == 0 or c.args == ()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerWarm::test_warm_sleeps_delay_plus_jitter -v`
+Expected: FAIL — `IndexError: list index out of range` (no sleep was called).
+
+- [ ] **Step 3: Add `time` and `random` imports + delay/jitter sleep at top of `warm()`**
+
+Modify `src/zodb_pgjsonb/cache_warmer.py`. Replace the import block at lines 12-13:
+
+```python
+import contextlib
+import logging
+import random
+import time
+```
+
+Then in `warm()`, insert the delay+jitter sleep as the very first statement of the method body (before the `from ZODB.utils import p64` line at 141):
+
+```python
+    def warm(self, load_multiple_fn):
+        """Load top-N ZOIDs into the shared cache.
+
+        Runs in a background daemon thread.  Primes the consensus TID
+        on the shared cache to the current PG max_tid so that
+        subsequent ``shared.set`` calls are accepted.  Re-reads
+        consensus after ``poll_advance`` and uses that as the
+        ``polled_tid`` for set calls — this is the mitigation for the
+        startup race where an instance's poll advances consensus past
+        the warmer's sampled TID before the set loop begins.
+
+        Skips warmup when the TID is unavailable.  Logs a WARNING when
+        every set() was rejected despite a non-empty result set (a
+        likely sign of the race being wider than this mitigation
+        covers).
+        """
+        # A2 + A1 (#59): get out of the pod's own cold-start window and
+        # smear lock-arrival times across pods so the cluster doesn't
+        # stampede the primary on rolling deploys.
+        if self._delay > 0 or self._jitter > 0:
+            time.sleep(self._delay + random.uniform(0, self._jitter))
+
+        from ZODB.utils import p64
+        from ZODB.utils import u64
+        # ... rest unchanged
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerWarm -v`
+Expected: PASS for both new tests and all pre-existing `TestCacheWarmerWarm` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zodb_pgjsonb/cache_warmer.py tests/test_cache_warmer.py
+git commit -m "feat(warmer): A2+A1 — startup delay + jitter sleep (#59)"
+```
+
+---
+
+## Task 3: A3 — paced batched warmup
+
+**Files:**
+
+- Modify: `src/zodb_pgjsonb/cache_warmer.py:154-203` (load + set loop in `warm()`)
+- Test: `tests/test_cache_warmer.py` (extend `TestCacheWarmerWarm`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cache_warmer.py` inside `TestCacheWarmerWarm`:
+
+```python
+    def test_warm_batches_with_pause(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        # 1100 OIDs at batch_size=500 → 3 batches (500+500+100),
+        # 2 inter-batch sleeps (after batches 1 and 2, not after 3).
+        top = list(range(1, 1101))
+        shared = SharedLoadCache(max_mb=64)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=top),
+            target_count=1100,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            batch_size=500,
+            batch_pause=0.25,
+        )
+
+        call_chunks = []
+
+        def loader(oids):
+            call_chunks.append(len(oids))
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        with mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep:
+            w.warm(loader)
+
+        # Three loader calls, sizes 500, 500, 100.
+        assert call_chunks == [500, 500, 100]
+        # Exactly two batch_pause sleeps of 0.25 (no trailing).
+        pause_calls = [c for c in mock_sleep.call_args_list if c.args == (0.25,)]
+        assert len(pause_calls) == 2
+
+    def test_warm_single_batch_no_pause(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2, 3]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            batch_size=500,
+            batch_pause=0.5,
+        )
+
+        def loader(oids):
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        with mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep:
+            w.warm(loader)
+
+        # Single batch → zero batch_pause sleeps.
+        pause_calls = [c for c in mock_sleep.call_args_list if c.args == (0.5,)]
+        assert pause_calls == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerWarm::test_warm_batches_with_pause tests/test_cache_warmer.py::TestCacheWarmerWarm::test_warm_single_batch_no_pause -v`
+Expected: FAIL — `assert call_chunks == [500, 500, 100]` fails because loader is called once with all 1100 OIDs.
+
+- [ ] **Step 3: Rewrite the load + set portion of `warm()` to batch**
+
+Modify `src/zodb_pgjsonb/cache_warmer.py`. Replace lines 154-203 (everything from `oids = [p64(z) for z in top_zoids]` to the end of the function) with:
+
+```python
+        # Prime consensus so set() accepts our writes.  Another instance
+        # may have advanced consensus beyond our sampled current_tid
+        # already — in that case poll_advance is a no-op, and the actual
+        # consensus is higher than current_tid.  Re-read it so our
+        # subsequent set() calls use the effective consensus as their
+        # polled_tid and pass the gate.
+        self._shared_cache.poll_advance(new_tid=current_tid, changed_zoids=[])
+        effective_tid = self._shared_cache.consensus_tid
+        if effective_tid is None:  # guarded for paranoia; should not happen
+            log.warning("Cache warmer: consensus still None after poll_advance")
+            return
+
+        # A3 (#59): batch the fetches and pause between them so a single
+        # pod's warmup doesn't burst the connection pool / DB CPU.
+        batch_size = max(1, self._batch_size)
+        batches = [
+            top_zoids[i:i + batch_size]
+            for i in range(0, len(top_zoids), batch_size)
+        ]
+        written = 0
+        attempted = 0
+        for batch_idx, batch in enumerate(batches):
+            oids = [p64(z) for z in batch]
+            try:
+                results = load_multiple_fn(oids)
+            except Exception:
+                log.warning(
+                    "Cache warmer: load_multiple failed at batch %d/%d",
+                    batch_idx + 1, len(batches),
+                    exc_info=True,
+                )
+                return
+            for oid, (data, tid_bytes) in results.items():
+                attempted += 1
+                if self._shared_cache.set(
+                    zoid=u64(oid),
+                    data=data,
+                    tid_bytes=tid_bytes,
+                    polled_tid=effective_tid,
+                ):
+                    written += 1
+            # Pause only between batches, never after the last.
+            if batch_idx < len(batches) - 1 and self._batch_pause > 0:
+                time.sleep(self._batch_pause)
+
+        if attempted == 0:
+            log.info("Cache warmer: load_multiple returned no objects")
+            return
+
+        if written == 0:
+            log.warning(
+                "Cache warmer: all %d set() calls rejected by shared cache "
+                "(consensus=%d, sampled_tid=%d) — likely raced with a "
+                "concurrent instance poll",
+                attempted,
+                effective_tid,
+                current_tid,
+            )
+        else:
+            log.info(
+                "Cache warmer: loaded %d of %d objects into shared cache "
+                "(%d batches)",
+                written,
+                attempted,
+                len(batches),
+            )
+```
+
+Note: this replaces the prior `try/except` around the single `load_multiple_fn` call (lines 155-159) and the prior `if not results` early-return (lines 161-163). The empty-result case is now detected via `attempted == 0` after the loop.
+
+- [ ] **Step 4: Run all warmer tests**
+
+Run: `uv run pytest tests/test_cache_warmer.py -v`
+Expected: All pre-existing tests still pass (including the prior `test_warm_handles_load_multiple_exception` since the per-batch `try/except` still catches the exception). Both new tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zodb_pgjsonb/cache_warmer.py tests/test_cache_warmer.py
+git commit -m "feat(warmer): A3 — paced batched warmup (#59)"
+```
+
+---
+
+## Task 4: B2b — `_try_acquire_slot_once` helper (single attempt across all slots)
+
+**Files:**
+
+- Modify: `src/zodb_pgjsonb/cache_warmer.py` (add module-level constants + new method)
+- Test: `tests/test_cache_warmer.py` (new `TestCacheWarmerSlot` class)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_cache_warmer.py`, after `TestCacheWarmerWarm`:
+
+```python
+class TestCacheWarmerSlot:
+    """Unit tests for the B2b advisory-lock slot helpers."""
+
+    def _make_lock_conn(self, slot_results):
+        """Return a mock connection whose execute('SELECT pg_try_advisory_lock(...)')
+        returns ``slot_results[i]`` on the i-th call (one row, one column).
+        """
+        call_count = [0]
+
+        class _LockCursor:
+            def __init__(self):
+                self._row = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def execute(self, sql, params=None):
+                if "pg_try_advisory_lock" in sql:
+                    i = call_count[0]
+                    call_count[0] += 1
+                    self._row = (slot_results[i],) if i < len(slot_results) else (False,)
+                else:
+                    self._row = None
+                return self
+
+            def fetchone(self):
+                return self._row
+
+        class _LockConn:
+            def cursor(self):
+                return _LockCursor()
+
+            def execute(self, *a, **kw):
+                return None
+
+            def close(self):
+                pass
+
+        return _LockConn()
+
+    def test_try_acquire_slot_returns_slot_when_first_free(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=3,
+        )
+        lock_conn = self._make_lock_conn(slot_results=[True])
+        slot = w._try_acquire_slot_once(lock_conn)
+        assert slot == 1
+
+    def test_try_acquire_slot_returns_higher_slot_when_first_taken(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=3,
+        )
+        lock_conn = self._make_lock_conn(slot_results=[False, False, True])
+        slot = w._try_acquire_slot_once(lock_conn)
+        assert slot == 3
+
+    def test_try_acquire_slot_returns_none_when_all_taken(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=3,
+        )
+        lock_conn = self._make_lock_conn(slot_results=[False, False, False])
+        slot = w._try_acquire_slot_once(lock_conn)
+        assert slot is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerSlot -v`
+Expected: FAIL — `AttributeError: 'CacheWarmer' object has no attribute '_try_acquire_slot_once'`.
+
+- [ ] **Step 3: Add constants + `_try_acquire_slot_once` method**
+
+Modify `src/zodb_pgjsonb/cache_warmer.py`. After the existing `WARM_STATS_DDL = ...` block (around line 24), add:
+
+```python
+# Advisory-lock keyspace for B2b inter-pod warmer semaphore (#59).
+# Same namespace as startup_locks.py (separate keys).
+WARMER_LOCK_NS = 0x5A4442    # "ZDB"
+WARMER_SLOT_BASE = 100       # slot keys are WARMER_SLOT_BASE + i for i in 1..N
+```
+
+Then add a new method on `CacheWarmer` (place it just before the `# ── Warming phase ──` comment, so it sits between the recording phase and the warming phase):
+
+```python
+    # ── B2b slot acquisition (#59) ───────────────────────────────────
+
+    def _try_acquire_slot_once(self, lock_conn):
+        """Try each slot 1..concurrency once.  Returns the acquired
+        slot number, or None if all slots are taken.
+
+        ``lock_conn`` must be an autocommit psycopg connection
+        dedicated to holding the session-level advisory lock.
+        """
+        for slot in range(1, self._concurrency + 1):
+            key = WARMER_SLOT_BASE + slot
+            try:
+                with lock_conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT pg_try_advisory_lock(%s, %s)",
+                        (WARMER_LOCK_NS, key),
+                    )
+                    row = cur.fetchone()
+            except Exception:
+                log.warning(
+                    "Cache warmer: pg_try_advisory_lock raised for slot %d",
+                    slot,
+                    exc_info=True,
+                )
+                return None
+            if row and row[0]:
+                return slot
+        return None
+```
+
+Note: `row[0]` indexes the tuple from a default psycopg cursor (the `_LockCursor` in the test returns a tuple). The real production lock connection is opened without `row_factory=dict_row`, so it also yields tuples. This is intentional — the dedicated lock connection is plain.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerSlot -v`
+Expected: PASS (all three tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zodb_pgjsonb/cache_warmer.py tests/test_cache_warmer.py
+git commit -m "feat(warmer): B2b — _try_acquire_slot_once helper (#59)"
+```
+
+---
+
+## Task 5: B2b — `_acquire_slot` with retry loop + wait cap
+
+**Files:**
+
+- Modify: `src/zodb_pgjsonb/cache_warmer.py` (add new method + module-level helper)
+- Test: `tests/test_cache_warmer.py` (extend `TestCacheWarmerSlot`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_cache_warmer.py` inside `TestCacheWarmerSlot`:
+
+```python
+    def test_acquire_slot_succeeds_after_retries(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        # First two attempts: all slots taken.  Third attempt: slot 1 free.
+        # With concurrency=2 that's 2 + 2 + 1 = 5 try-lock calls before success.
+        slot_results = [False, False] + [False, False] + [True]
+        lock_conn = self._make_lock_conn(slot_results=slot_results)
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+            wait_max=30,
+        )
+
+        # Patch psycopg.connect to return our pre-built lock_conn, and
+        # patch sleep so the test doesn't actually wait.
+        with mock.patch(
+            "zodb_pgjsonb.cache_warmer.psycopg.connect",
+            return_value=lock_conn,
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.time.sleep"
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.random.uniform",
+            return_value=3.0,
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.time.monotonic",
+            side_effect=[0, 3, 6, 9],
+        ):
+            conn, slot = w._acquire_slot()
+
+        assert conn is lock_conn
+        assert slot == 1
+
+    def test_acquire_slot_times_out(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        # All slots permanently taken.
+        lock_conn = self._make_lock_conn(slot_results=[False] * 100)
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+            wait_max=10,
+        )
+
+        # monotonic side_effect: simulate 0s, 3s, 6s, 9s, 12s — wait_max hit.
+        with mock.patch(
+            "zodb_pgjsonb.cache_warmer.psycopg.connect",
+            return_value=lock_conn,
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.time.sleep"
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.random.uniform",
+            return_value=3.0,
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.time.monotonic",
+            side_effect=[0, 3, 6, 9, 12],
+        ):
+            result = w._acquire_slot()
+
+        assert result is None
+
+    def test_acquire_slot_handles_connect_failure(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+            wait_max=30,
+        )
+
+        with mock.patch(
+            "zodb_pgjsonb.cache_warmer.psycopg.connect",
+            side_effect=RuntimeError("connect refused"),
+        ):
+            result = w._acquire_slot()
+
+        assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerSlot -v -k acquire_slot`
+Expected: FAIL — `AttributeError: ... '_acquire_slot'`.
+
+- [ ] **Step 3: Add `psycopg` import + `_acquire_slot` method**
+
+Modify `src/zodb_pgjsonb/cache_warmer.py`. Add to the import block at the top:
+
+```python
+import contextlib
+import logging
+import random
+import time
+
+import psycopg
+```
+
+Then add the `_acquire_slot` method on `CacheWarmer`, immediately after `_try_acquire_slot_once`:
+
+```python
+    def _acquire_slot(self):
+        """Acquire one of ``concurrency`` cluster-wide slots.
+
+        Opens a dedicated autocommit psycopg connection and tries each
+        slot via ``_try_acquire_slot_once`` in a retry loop.  Returns
+        ``(lock_conn, slot)`` on success or ``None`` on timeout / open
+        failure.
+
+        Caller is responsible for releasing the slot and closing the
+        connection (see ``_release_slot``).  Session-level advisory
+        locks auto-release on connection close, so a pod crash mid-warm
+        safely frees the slot.
+        """
+        if self._dsn is None or self._concurrency < 1:
+            return None
+        try:
+            lock_conn = psycopg.connect(self._dsn, autocommit=True)
+        except Exception:
+            log.warning(
+                "Cache warmer: failed to open lock connection, skipping warmup",
+                exc_info=True,
+            )
+            return None
+
+        started = time.monotonic()
+        attempt = 0
+        try:
+            while True:
+                attempt += 1
+                slot = self._try_acquire_slot_once(lock_conn)
+                if slot is not None:
+                    waited = time.monotonic() - started
+                    log.info(
+                        "Cache warmer: acquired slot %d after %.1fs wait "
+                        "(attempt %d)",
+                        slot, waited, attempt,
+                    )
+                    return lock_conn, slot
+
+                waited = time.monotonic() - started
+                if waited >= self._wait_max:
+                    log.warning(
+                        "Cache warmer: gave up after %.1fs waiting for slot "
+                        "(%d attempts), skipping warmup",
+                        waited, attempt,
+                    )
+                    return None
+
+                log.info(
+                    "Cache warmer: all %d slots taken, retrying "
+                    "(waited %.1fs so far)",
+                    self._concurrency, waited,
+                )
+                time.sleep(random.uniform(2.0, 5.0))
+        except Exception:
+            log.warning(
+                "Cache warmer: unexpected error in slot acquisition",
+                exc_info=True,
+            )
+            with contextlib.suppress(Exception):
+                lock_conn.close()
+            return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerSlot -v`
+Expected: PASS (all six tests including the new three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zodb_pgjsonb/cache_warmer.py tests/test_cache_warmer.py
+git commit -m "feat(warmer): B2b — _acquire_slot with retry loop and wait cap (#59)"
+```
+
+---
+
+## Task 6: B2b — `_release_slot` (release + close lock connection)
+
+**Files:**
+
+- Modify: `src/zodb_pgjsonb/cache_warmer.py` (add `_release_slot` method)
+- Test: `tests/test_cache_warmer.py` (extend `TestCacheWarmerSlot`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cache_warmer.py` inside `TestCacheWarmerSlot`:
+
+```python
+    def test_release_slot_unlocks_and_closes(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.cache_warmer import WARMER_LOCK_NS
+        from zodb_pgjsonb.cache_warmer import WARMER_SLOT_BASE
+
+        executed = []
+        closed = []
+
+        class _ReleaseConn:
+            def execute(self, sql, params=None):
+                executed.append((sql, params))
+
+            def close(self):
+                closed.append(True)
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=2,
+        )
+        lock_conn = _ReleaseConn()
+        w._release_slot(lock_conn, slot=2)
+
+        assert len(executed) == 1
+        sql, params = executed[0]
+        assert "pg_advisory_unlock" in sql
+        assert params == (WARMER_LOCK_NS, WARMER_SLOT_BASE + 2)
+        assert closed == [True]
+
+    def test_release_slot_swallows_errors(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        class _BadConn:
+            def execute(self, sql, params=None):
+                raise RuntimeError("connection gone")
+
+            def close(self):
+                raise RuntimeError("close gone too")
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=2,
+        )
+        # Must not raise.
+        w._release_slot(_BadConn(), slot=1)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerSlot -v -k release_slot`
+Expected: FAIL — `AttributeError: ... '_release_slot'`.
+
+- [ ] **Step 3: Add `_release_slot` method**
+
+In `src/zodb_pgjsonb/cache_warmer.py`, after `_acquire_slot`, add:
+
+```python
+    def _release_slot(self, lock_conn, slot):
+        """Release the advisory lock and close the dedicated connection.
+
+        Errors are logged and suppressed — PG auto-releases session
+        locks on connection close, so a failed unlock is recoverable.
+        """
+        key = WARMER_SLOT_BASE + slot
+        try:
+            lock_conn.execute(
+                "SELECT pg_advisory_unlock(%s, %s)",
+                (WARMER_LOCK_NS, key),
+            )
+        except Exception:
+            log.warning(
+                "Cache warmer: pg_advisory_unlock failed for slot %d",
+                slot,
+                exc_info=True,
+            )
+        with contextlib.suppress(Exception):
+            lock_conn.close()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerSlot -v`
+Expected: PASS (all eight tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zodb_pgjsonb/cache_warmer.py tests/test_cache_warmer.py
+git commit -m "feat(warmer): B2b — _release_slot helper (#59)"
+```
+
+---
+
+## Task 7: Integrate slot lifecycle into `warm()`
+
+**Files:**
+
+- Modify: `src/zodb_pgjsonb/cache_warmer.py:warm()` (wrap warming with acquire/release)
+- Test: `tests/test_cache_warmer.py` (extend `TestCacheWarmerWarm`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cache_warmer.py` inside `TestCacheWarmerWarm`:
+
+```python
+    def test_warm_acquires_and_releases_slot(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+        )
+        # Pretend slot acquisition succeeds without touching PG.
+        acquire_calls = []
+        release_calls = []
+
+        def fake_acquire():
+            sentinel = object()
+            acquire_calls.append(sentinel)
+            return (sentinel, 1)
+
+        def fake_release(lock_conn, slot):
+            release_calls.append((lock_conn, slot))
+
+        w._acquire_slot = fake_acquire
+        w._release_slot = fake_release
+
+        def loader(oids):
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        w.warm(loader)
+        assert len(acquire_calls) == 1
+        assert len(release_calls) == 1
+        assert release_calls[0][1] == 1  # slot number
+        assert release_calls[0][0] is acquire_calls[0]  # same conn
+
+    def test_warm_skips_on_acquire_failure(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+        )
+        w._acquire_slot = lambda: None
+
+        load_called = []
+
+        def loader(oids):
+            load_called.append(oids)
+            return {}
+
+        w.warm(loader)
+        # No load when acquire fails.
+        assert load_called == []
+        assert len(shared._cache) == 0
+
+    def test_warm_no_slot_when_concurrency_zero(self):
+        """When concurrency=0, the slot path is bypassed entirely
+        (preserves backward-compat for direct test instantiation)."""
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            concurrency=0,
+        )
+        acquired = []
+        w._acquire_slot = lambda: acquired.append(True) or None
+
+        def loader(oids):
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        w.warm(loader)
+        # _acquire_slot must not be called when concurrency=0.
+        assert acquired == []
+        # Warming still happens.
+        assert len(shared._cache) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerWarm -v -k 'acquire or skips_on_acquire or concurrency_zero'`
+Expected: FAIL — `assert len(acquire_calls) == 1` fails because `warm()` doesn't call `_acquire_slot`.
+
+- [ ] **Step 3: Wrap warming with acquire/release**
+
+Modify `src/zodb_pgjsonb/cache_warmer.py:warm()`. The current structure is:
+
+```python
+def warm(self, load_multiple_fn):
+    """..."""
+    # A2 + A1 sleep
+    ...
+    from ZODB.utils import p64
+    from ZODB.utils import u64
+
+    top_zoids = self._read_top_oids()
+    if not top_zoids:
+        ...
+        return
+
+    current_tid = self._load_current_tid_fn()
+    ...
+    # batched load + set
+```
+
+Insert slot acquisition between the sleep and `_read_top_oids`, and wrap the rest in a try/finally for release. Replace the body of `warm()` from the A2+A1 sleep onwards with:
+
+```python
+        # A2 + A1 (#59): get out of the pod's own cold-start window and
+        # smear lock-arrival times across pods so the cluster doesn't
+        # stampede the primary on rolling deploys.
+        if self._delay > 0 or self._jitter > 0:
+            time.sleep(self._delay + random.uniform(0, self._jitter))
+
+        # B2b (#59): try to claim one of N cluster-wide slots.  When
+        # concurrency is 0 or no DSN is configured, the semaphore is
+        # disabled and warming proceeds unconditionally.
+        lock_conn = None
+        slot = None
+        if self._concurrency >= 1:
+            acquired = self._acquire_slot()
+            if acquired is None:
+                # Acquire failed (timeout or connect error); already
+                # logged inside _acquire_slot.
+                return
+            lock_conn, slot = acquired
+
+        try:
+            self._warm_body(load_multiple_fn)
+        finally:
+            if lock_conn is not None:
+                self._release_slot(lock_conn, slot)
+```
+
+Replace the entire `warm()` method in `src/zodb_pgjsonb/cache_warmer.py` with the following two methods (the Task 3 batched-load logic moves into `_warm_body`):
+
+```python
+    def warm(self, load_multiple_fn):
+        """Load top-N ZOIDs into the shared cache.
+
+        Runs in a background daemon thread.  Orchestrates the four
+        herd-mitigation phases (#59): startup delay + jitter (A2+A1),
+        cluster-wide slot acquisition (B2b), paced batched warmup (A3),
+        slot release.
+        """
+        # A2 + A1: get out of the pod's own cold-start window and
+        # smear lock-arrival times across pods so the cluster doesn't
+        # stampede the primary on rolling deploys.
+        if self._delay > 0 or self._jitter > 0:
+            time.sleep(self._delay + random.uniform(0, self._jitter))
+
+        # B2b: try to claim one of N cluster-wide slots.  When
+        # concurrency is 0 the semaphore is disabled.
+        lock_conn = None
+        slot = None
+        if self._concurrency >= 1:
+            acquired = self._acquire_slot()
+            if acquired is None:
+                # Already logged inside _acquire_slot (timeout or open failure).
+                return
+            lock_conn, slot = acquired
+
+        try:
+            self._warm_body(load_multiple_fn)
+        finally:
+            if lock_conn is not None:
+                self._release_slot(lock_conn, slot)
+
+    def _warm_body(self, load_multiple_fn):
+        """Top-OID read + prime-consensus + paced batched load+set.
+
+        Primes the consensus TID on the shared cache to the current PG
+        max_tid so that subsequent ``shared.set`` calls are accepted.
+        Re-reads consensus after ``poll_advance`` and uses that as the
+        ``polled_tid`` for set calls — this is the mitigation for the
+        startup race where an instance's poll advances consensus past
+        the warmer's sampled TID before the set loop begins.
+
+        Skips warmup when the TID is unavailable.  Logs a WARNING when
+        every set() was rejected despite a non-empty result set.
+        """
+        from ZODB.utils import p64
+        from ZODB.utils import u64
+
+        top_zoids = self._read_top_oids()
+        if not top_zoids:
+            log.info("Cache warmer: no stats yet, skipping warmup")
+            return
+
+        current_tid = self._load_current_tid_fn()
+        if current_tid is None:
+            log.warning("Cache warmer: could not read current TID, skipping warmup")
+            return
+
+        # Prime consensus so set() accepts our writes.  Another instance
+        # may have advanced consensus beyond our sampled current_tid
+        # already — in that case poll_advance is a no-op, and the actual
+        # consensus is higher than current_tid.  Re-read it so our
+        # subsequent set() calls use the effective consensus as their
+        # polled_tid and pass the gate.
+        self._shared_cache.poll_advance(new_tid=current_tid, changed_zoids=[])
+        effective_tid = self._shared_cache.consensus_tid
+        if effective_tid is None:  # guarded for paranoia; should not happen
+            log.warning("Cache warmer: consensus still None after poll_advance")
+            return
+
+        # A3: batch the fetches and pause between them so a single
+        # pod's warmup doesn't burst the connection pool / DB CPU.
+        batch_size = max(1, self._batch_size)
+        batches = [
+            top_zoids[i:i + batch_size]
+            for i in range(0, len(top_zoids), batch_size)
+        ]
+        written = 0
+        attempted = 0
+        for batch_idx, batch in enumerate(batches):
+            oids = [p64(z) for z in batch]
+            try:
+                results = load_multiple_fn(oids)
+            except Exception:
+                log.warning(
+                    "Cache warmer: load_multiple failed at batch %d/%d",
+                    batch_idx + 1, len(batches),
+                    exc_info=True,
+                )
+                return
+            for oid, (data, tid_bytes) in results.items():
+                attempted += 1
+                if self._shared_cache.set(
+                    zoid=u64(oid),
+                    data=data,
+                    tid_bytes=tid_bytes,
+                    polled_tid=effective_tid,
+                ):
+                    written += 1
+            # Pause only between batches, never after the last.
+            if batch_idx < len(batches) - 1 and self._batch_pause > 0:
+                time.sleep(self._batch_pause)
+
+        if attempted == 0:
+            log.info("Cache warmer: load_multiple returned no objects")
+            return
+
+        if written == 0:
+            log.warning(
+                "Cache warmer: all %d set() calls rejected by shared cache "
+                "(consensus=%d, sampled_tid=%d) — likely raced with a "
+                "concurrent instance poll",
+                attempted,
+                effective_tid,
+                current_tid,
+            )
+        else:
+            log.info(
+                "Cache warmer: loaded %d of %d objects into shared cache "
+                "(%d batches)",
+                written,
+                attempted,
+                len(batches),
+            )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_warmer.py -v`
+Expected: All tests pass — the three new tests plus all pre-existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zodb_pgjsonb/cache_warmer.py tests/test_cache_warmer.py
+git commit -m "feat(warmer): B2b — integrate slot lifecycle into warm() (#59)"
+```
+
+---
+
+## Task 8: Storage.py wiring — production defaults + DSN passthrough
+
+**Files:**
+
+- Modify: `src/zodb_pgjsonb/storage.py:380-397` (`PGJsonbStorage.__init__` signature) and lines 527-541 (CacheWarmer instantiation)
+- Test: existing `tests/test_storage*.py` (regression check only)
+
+- [ ] **Step 1: Extend `PGJsonbStorage.__init__` signature**
+
+Modify `src/zodb_pgjsonb/storage.py`. Find the existing `__init__` signature (around line 380):
+
+```python
+    def __init__(
+        self,
+        dsn,
+        name="pgjsonb",
+        history_preserving=False,
+        blob_temp_dir=None,
+        cache_local_mb=None,  # deprecated alias for cache_shared_mb
+        cache_shared_mb=256,
+        cache_per_connection_mb=16,
+        pool_size=1,
+        pool_max_size=10,
+        pool_timeout=30.0,
+        s3_client=None,
+        blob_cache=None,
+        blob_threshold=102_400,
+        cache_warm_pct=10,
+        cache_warm_decay=0.8,
+    ):
+```
+
+Add the six new keyword arguments at the end (preserving the existing kwargs and their defaults):
+
+```python
+    def __init__(
+        self,
+        dsn,
+        name="pgjsonb",
+        history_preserving=False,
+        blob_temp_dir=None,
+        cache_local_mb=None,  # deprecated alias for cache_shared_mb
+        cache_shared_mb=256,
+        cache_per_connection_mb=16,
+        pool_size=1,
+        pool_max_size=10,
+        pool_timeout=30.0,
+        s3_client=None,
+        blob_cache=None,
+        blob_threshold=102_400,
+        cache_warm_pct=10,
+        cache_warm_decay=0.8,
+        cache_warm_delay=15,
+        cache_warm_jitter=30,
+        cache_warm_concurrency=2,
+        cache_warm_wait_max=300,
+        cache_warm_batch_size=500,
+        cache_warm_batch_pause=0.5,
+    ):
+```
+
+- [ ] **Step 2: Forward new kwargs to CacheWarmer**
+
+In `src/zodb_pgjsonb/storage.py`, find the existing `self._warmer = CacheWarmer(...)` call (around line 527) and extend it to:
+
+```python
+            self._warmer = CacheWarmer(
+                self._conn,
+                target_count=target,
+                shared_cache=self._shared_cache,
+                load_current_tid_fn=self.current_max_tid,
+                dsn=self._dsn,
+                decay=cache_warm_decay,
+                delay=cache_warm_delay,
+                jitter=cache_warm_jitter,
+                concurrency=cache_warm_concurrency,
+                wait_max=cache_warm_wait_max,
+                batch_size=cache_warm_batch_size,
+                batch_pause=cache_warm_batch_pause,
+            )
+```
+
+- [ ] **Step 3: Update the existing INFO log**
+
+Find the existing `logger.info("Cache warmer started (target=%d, decay=%.1f)", ...)` (around line 542) and replace with:
+
+```python
+            logger.info(
+                "Cache warmer started (target=%d, decay=%.1f, delay=%ds, "
+                "jitter=%ds, concurrency=%d, batch_size=%d, batch_pause=%.2fs)",
+                target,
+                cache_warm_decay,
+                cache_warm_delay,
+                cache_warm_jitter,
+                cache_warm_concurrency,
+                cache_warm_batch_size,
+                cache_warm_batch_pause,
+            )
+```
+
+- [ ] **Step 4: Run full storage and warmer test suite**
+
+Run: `uv run pytest tests/test_storage.py tests/test_cache_warmer.py -v`
+Expected: All pre-existing tests pass. The new behavior is now active when `PGJsonbStorage` is constructed without overrides, but storage tests typically pass `cache_warm_pct=0` to disable the warmer entirely, so there is no observable change in those tests.
+
+If any storage test was relying on `CacheWarmer.__init__` having only its prior kwargs, update it to either set `cache_warm_pct=0` or pass the new kwargs explicitly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zodb_pgjsonb/storage.py
+git commit -m "feat(storage): wire herd-mitigation knobs into CacheWarmer (#59)"
+```
+
+---
+
+## Task 9: ZConfig keys + factory passthrough
+
+**Files:**
+
+- Modify: `src/zodb_pgjsonb/component.xml` (add six `<key>` elements)
+- Modify: `src/zodb_pgjsonb/config.py:70-90` (add to kwargs dict)
+- Test: `tests/test_config.py` if it exists, otherwise a smoke test
+
+- [ ] **Step 1: Add six ZConfig `<key>` elements**
+
+Modify `src/zodb_pgjsonb/component.xml`. Find the existing `<key name="cache-warm-decay" ...>` block (around line 90). Immediately after its closing `</key>`, insert:
+
+```xml
+    <key name="cache-warm-delay" datatype="integer" default="15">
+      <description>
+        Baseline sleep (seconds) before the cache warmer starts work.
+        Moves the warmer out of the pod's own cold-start window so it
+        does not compete with Plone import + plone.pgcatalog schema
+        checks + ANALYZE chatter.  Set to 0 to disable.  Default: 15.
+        See issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-jitter" datatype="integer" default="30">
+      <description>
+        Additional uniform-random sleep (0..jitter seconds) on top of
+        cache-warm-delay.  Spreads warmer arrival times across pods so
+        a rolling deploy does not produce a synchronous DB burst.  Set
+        to 0 to disable.  Default: 30.  See issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-concurrency" datatype="integer" default="2">
+      <description>
+        Maximum number of pods warming concurrently in the cluster,
+        enforced via PostgreSQL advisory locks.  Set to a very large
+        value (e.g. 9999) to effectively disable the cap.  Default: 2.
+        See issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-wait-max" datatype="integer" default="300">
+      <description>
+        Maximum time (seconds) to wait for a free slot before giving
+        up and skipping warmup (logs a WARNING).  Default: 300.  See
+        issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-batch-size" datatype="integer" default="500">
+      <description>
+        Number of ZOIDs fetched per SELECT batch during warmup.  Lower
+        values reduce peak qps at the cost of longer warmup duration.
+        Default: 500.  See issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-batch-pause" datatype="float" default="0.5">
+      <description>
+        Sleep (seconds) between warmup batches.  Lowers per-pod peak
+        qps.  Set to 0 to disable.  Default: 0.5.  See issue #59.
+      </description>
+    </key>
+```
+
+- [ ] **Step 2: Add the six keys to the factory kwargs dict**
+
+Modify `src/zodb_pgjsonb/config.py`. Find the existing kwargs dict (around lines 70-83) that ends with `"cache_warm_decay": getattr(config, "cache_warm_decay", 0.8),`. Extend it:
+
+```python
+            "cache_warm_pct": getattr(config, "cache_warm_pct", 10),
+            "cache_warm_decay": getattr(config, "cache_warm_decay", 0.8),
+            "cache_warm_delay": getattr(config, "cache_warm_delay", 15),
+            "cache_warm_jitter": getattr(config, "cache_warm_jitter", 30),
+            "cache_warm_concurrency": getattr(
+                config, "cache_warm_concurrency", 2
+            ),
+            "cache_warm_wait_max": getattr(config, "cache_warm_wait_max", 300),
+            "cache_warm_batch_size": getattr(
+                config, "cache_warm_batch_size", 500
+            ),
+            "cache_warm_batch_pause": getattr(
+                config, "cache_warm_batch_pause", 0.5
+            ),
+        }
+```
+
+- [ ] **Step 3: Smoke-test the ZConfig parse path**
+
+Find any existing test that parses a `<pgjsonb>` block (e.g. `tests/test_config.py` if present, or grep for `PGJsonbStorageFactory` in tests). If none exists, add to `tests/test_config.py` (create the file if needed):
+
+```python
+"""Smoke tests for the ZConfig factory wiring."""
+
+from io import StringIO
+import pytest
+import ZConfig
+
+
+SCHEMA = """\
+<schema>
+    <import package="zodb_pgjsonb" />
+    <section type="pgjsonb" name="*" attribute="storage" />
+</schema>
+"""
+
+
+def test_warm_knobs_default_through_factory(tmp_path):
+    cfg_text = """\
+%import zodb_pgjsonb
+<pgjsonb test>
+    dsn dbname=test
+</pgjsonb>
+"""
+    schema = ZConfig.loadSchemaFile(StringIO(SCHEMA))
+    cfg, _ = ZConfig.loadConfigFile(schema, StringIO(cfg_text))
+    section = cfg.storage.config
+    assert getattr(section, "cache_warm_delay", None) == 15
+    assert getattr(section, "cache_warm_jitter", None) == 30
+    assert getattr(section, "cache_warm_concurrency", None) == 2
+    assert getattr(section, "cache_warm_wait_max", None) == 300
+    assert getattr(section, "cache_warm_batch_size", None) == 500
+    assert getattr(section, "cache_warm_batch_pause", None) == 0.5
+
+
+def test_warm_knobs_overridden_through_factory():
+    cfg_text = """\
+%import zodb_pgjsonb
+<pgjsonb test>
+    dsn dbname=test
+    cache-warm-delay 0
+    cache-warm-jitter 0
+    cache-warm-concurrency 9999
+    cache-warm-batch-pause 0
+</pgjsonb>
+"""
+    schema = ZConfig.loadSchemaFile(StringIO(SCHEMA))
+    cfg, _ = ZConfig.loadConfigFile(schema, StringIO(cfg_text))
+    section = cfg.storage.config
+    assert section.cache_warm_delay == 0
+    assert section.cache_warm_jitter == 0
+    assert section.cache_warm_concurrency == 9999
+    assert section.cache_warm_batch_pause == 0
+```
+
+- [ ] **Step 4: Run the smoke test**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: PASS for both new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/zodb_pgjsonb/component.xml src/zodb_pgjsonb/config.py tests/test_config.py
+git commit -m "feat(config): six ZConfig keys for cache-warm herd mitigation (#59)"
+```
+
+---
+
+## Task 10: DB integration test — slot serialization with `concurrency=1`
+
+**Files:**
+
+- Modify: `tests/test_cache_warmer.py` (extend `TestCacheWarmerDB`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cache_warmer.py` inside `TestCacheWarmerDB`:
+
+```python
+    def test_concurrency_1_serializes_two_warmers(self):
+        """Two warmers with concurrency=1 must not warm in parallel."""
+        from ZODB.utils import p64
+        from tests.conftest import DSN
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        import threading
+        import time
+
+        # Seed warm stats so the warmers have something to do.
+        self.conn.execute(
+            "INSERT INTO cache_warm_stats (zoid, score) "
+            "VALUES (1, 5.0), (2, 4.0), (3, 3.0)"
+        )
+
+        shared = SharedLoadCache(max_mb=4)
+        load_times = []
+
+        def slow_loader(oids):
+            load_times.append(("enter", time.monotonic()))
+            time.sleep(0.5)  # simulate slow load
+            load_times.append(("exit", time.monotonic()))
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        def run_warmer():
+            w = CacheWarmer(
+                conn=self.conn,
+                target_count=10,
+                shared_cache=shared,
+                load_current_tid_fn=lambda: 100,
+                dsn=DSN,
+                concurrency=1,
+                wait_max=30,
+                batch_size=500,
+                batch_pause=0,
+            )
+            w.warm(slow_loader)
+
+        t1 = threading.Thread(target=run_warmer)
+        t2 = threading.Thread(target=run_warmer)
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        # Two enter/exit pairs, non-overlapping.
+        enters = sorted(t for k, t in load_times if k == "enter")
+        exits = sorted(t for k, t in load_times if k == "exit")
+        assert len(enters) == 2 and len(exits) == 2
+        # Either exits[0] <= enters[1] (serialized) — strict serialization
+        # by the advisory lock.
+        assert exits[0] <= enters[1] + 0.05  # 50ms slack for thread sched
+```
+
+- [ ] **Step 2: Run the test to verify it fails before implementation is fully wired**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerDB::test_concurrency_1_serializes_two_warmers -v`
+Expected: This test should already PASS if Tasks 1-7 are wired correctly, because all the production code is already in place. (This is an integration test, not a TDD step — its purpose is to confirm the end-to-end wiring is correct against a real PostgreSQL.)
+
+If it FAILS, debug the integration before continuing — likely culprits: lock-connection not opened in autocommit, wrong key namespace, slot accounting off by one.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_cache_warmer.py
+git commit -m "test(warmer): DB integration — slot serialization with concurrency=1 (#59)"
+```
+
+---
+
+## Task 11: DB integration test — N-slot semaphore with `concurrency=2`
+
+**Files:**
+
+- Modify: `tests/test_cache_warmer.py` (extend `TestCacheWarmerDB`)
+
+- [ ] **Step 1: Write the test**
+
+Add to `tests/test_cache_warmer.py` inside `TestCacheWarmerDB`:
+
+```python
+    def test_concurrency_2_allows_two_parallel_one_waits(self):
+        """Three warmers, concurrency=2 — two warm in parallel, third waits."""
+        from ZODB.utils import p64
+        from tests.conftest import DSN
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        import threading
+        import time
+
+        self.conn.execute(
+            "INSERT INTO cache_warm_stats (zoid, score) "
+            "VALUES (1, 5.0), (2, 4.0), (3, 3.0)"
+        )
+
+        shared = SharedLoadCache(max_mb=4)
+        load_events = []
+        load_events_lock = threading.Lock()
+
+        def slow_loader(oids):
+            with load_events_lock:
+                load_events.append(("enter", time.monotonic()))
+            time.sleep(0.5)
+            with load_events_lock:
+                load_events.append(("exit", time.monotonic()))
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        def run_warmer():
+            w = CacheWarmer(
+                conn=self.conn,
+                target_count=10,
+                shared_cache=shared,
+                load_current_tid_fn=lambda: 100,
+                dsn=DSN,
+                concurrency=2,
+                wait_max=30,
+                batch_size=500,
+                batch_pause=0,
+            )
+            w.warm(slow_loader)
+
+        threads = [threading.Thread(target=run_warmer) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        enters = sorted(t for k, t in load_events if k == "enter")
+        exits = sorted(t for k, t in load_events if k == "exit")
+        assert len(enters) == 3 and len(exits) == 3
+        # First two enters within a small window (parallel), third
+        # enter must be after at least one exit.
+        assert enters[1] - enters[0] < 0.3
+        assert enters[2] >= exits[0] - 0.05  # 50ms slack
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerDB::test_concurrency_2_allows_two_parallel_one_waits -v`
+Expected: PASS.
+
+If FAIL, check that `_acquire_slot`'s retry loop uses the configured `wait_max` correctly and that the retry sleep is short enough to let a freed slot be picked up within the test window.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_cache_warmer.py
+git commit -m "test(warmer): DB integration — N-slot semaphore (concurrency=2) (#59)"
+```
+
+---
+
+## Task 12: DB integration test — crash-safe slot release on connection close
+
+**Files:**
+
+- Modify: `tests/test_cache_warmer.py` (extend `TestCacheWarmerDB`)
+
+- [ ] **Step 1: Write the test**
+
+Add to `tests/test_cache_warmer.py` inside `TestCacheWarmerDB`:
+
+```python
+    def test_lock_released_on_connection_close(self):
+        """If the warmer's lock connection closes (e.g. pod crash),
+        PG auto-releases the session-level lock so another warmer can
+        proceed."""
+        from tests.conftest import DSN
+        from zodb_pgjsonb.cache_warmer import (
+            CacheWarmer,
+            WARMER_LOCK_NS,
+            WARMER_SLOT_BASE,
+        )
+
+        import psycopg
+        from psycopg.rows import dict_row
+
+        # Pod 1: open a connection, acquire slot 1 manually.
+        conn1 = psycopg.connect(DSN, autocommit=True)
+        with conn1.cursor() as cur:
+            cur.execute(
+                "SELECT pg_try_advisory_lock(%s, %s)",
+                (WARMER_LOCK_NS, WARMER_SLOT_BASE + 1),
+            )
+            assert cur.fetchone()[0] is True
+
+        # Pod 2: a fresh warmer with concurrency=1 must time out quickly
+        # because slot 1 is held.
+        w = CacheWarmer(
+            conn=self.conn,
+            target_count=10,
+            shared_cache=type("S", (), {
+                "poll_advance": lambda *a, **k: None,
+                "set": lambda *a, **k: True,
+                "consensus_tid": 1,
+            })(),
+            load_current_tid_fn=lambda: 100,
+            dsn=DSN,
+            concurrency=1,
+            wait_max=3,  # very short, just to confirm contention
+        )
+        assert w._acquire_slot() is None
+
+        # Now close pod 1's connection — auto-releases the lock.
+        conn1.close()
+
+        # Pod 3: a new warmer should now acquire slot 1.
+        w2 = CacheWarmer(
+            conn=self.conn,
+            target_count=10,
+            shared_cache=type("S", (), {
+                "poll_advance": lambda *a, **k: None,
+                "set": lambda *a, **k: True,
+                "consensus_tid": 1,
+            })(),
+            load_current_tid_fn=lambda: 100,
+            dsn=DSN,
+            concurrency=1,
+            wait_max=10,
+        )
+        result = w2._acquire_slot()
+        assert result is not None
+        lock_conn, slot = result
+        assert slot == 1
+        # Clean up.
+        w2._release_slot(lock_conn, slot)
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerDB::test_lock_released_on_connection_close -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_cache_warmer.py
+git commit -m "test(warmer): DB integration — crash-safe slot release (#59)"
+```
+
+---
+
+## Task 13: CHANGES.md entry
+
+**Files:**
+
+- Modify: `CHANGES.md` (add a new top entry above 1.12.0)
+
+- [ ] **Step 1: Add changelog entry**
+
+Read the current `CHANGES.md` and identify the topmost release heading (e.g., `## 1.12.0`). Insert a new section above it:
+
+```markdown
+## 1.13.0 (unreleased)
+
+### Features
+
+- **Cache warmer herd mitigation** (#59).  Rolling Kubernetes deploys
+  used to multiply DB primary CPU by the replica count for the warmer
+  startup window, because every pod independently fired its full set
+  of warmup `SELECT`s simultaneously.  Four composable behaviors fix
+  this, all wired through six new ZConfig keys:
+
+  - `cache-warm-delay` (default 15s): baseline sleep before warmer
+    starts. Moves the warmer out of the pod's own cold-start window
+    (Plone import, plone.pgcatalog schema check, ANALYZE chatter).
+  - `cache-warm-jitter` (default 30s): additional `random(0, jitter)`
+    sleep on top.  Spreads arrival times across pods.
+  - `cache-warm-concurrency` (default 2): maximum number of pods
+    warming in parallel, cluster-wide.  Enforced via a session-level
+    PostgreSQL advisory lock semaphore (same pattern as the existing
+    startup-DDL lock).  Pods that miss a slot retry with jittered
+    backoff until `cache-warm-wait-max` expires.
+  - `cache-warm-wait-max` (default 300s): retry cap before giving up
+    and skipping warmup (logged as WARNING).
+  - `cache-warm-batch-size` (default 500): zoids per `SELECT` batch.
+  - `cache-warm-batch-pause` (default 0.5s): sleep between batches.
+    Lowers per-pod peak qps.
+
+  **Observable behavior change:** warmer queries are now delayed by
+  ~15–45s post-startup (delay + jitter), not immediate.  To restore
+  pre-1.13 behavior, set `cache-warm-delay=0`, `cache-warm-jitter=0`,
+  `cache-warm-batch-pause=0`, `cache-warm-concurrency=9999`.
+
+  **Last-pod latency:** for a 6-pod fleet with default settings, the
+  last pod has a warm L2 cache approximately 45s after the deploy
+  window.  All pods serve traffic from T+0; this is the time-to-warm,
+  not the time-to-ready.
+
+  Design: [docs/superpowers/specs/2026-05-29-cache-warmer-herd-mitigation-design.md](docs/superpowers/specs/2026-05-29-cache-warmer-herd-mitigation-design.md).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGES.md
+git commit -m "docs: changelog entry for cache warmer herd mitigation (#59)"
+```
+
+---
+
+## Task 14: Full test suite + lint pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run full unit test suite**
+
+Run: `uv run pytest tests/test_cache_warmer.py tests/test_config.py -v`
+Expected: All tests pass — pre-existing + the 18+ new tests added across Tasks 1-12.
+
+- [ ] **Step 2: Run DB integration tests**
+
+Run: `uv run pytest tests/test_cache_warmer.py -v -m db`
+Expected: All `@pytest.mark.db` tests pass against `localhost:5433`. If PostgreSQL is unavailable, the existing skip logic in `_setup_db` handles it.
+
+- [ ] **Step 3: Run linter and formatter**
+
+Run: `uv run ruff check .` then `uv run ruff format --check .`
+Expected: clean (or apply `ruff format .` if formatting changes are needed, then commit them as a separate `style:` commit).
+
+- [ ] **Step 4: Run full project test suite as a final regression check**
+
+Run: `uv run pytest`
+Expected: all tests pass; no regressions in storage / instance / serialization / shared-cache test modules.
+
+- [ ] **Step 5: If lint fixes are needed**
+
+```bash
+uv run ruff format .
+git add -u
+git commit -m "style: ruff format after herd-mitigation changes"
+```
+
+---
+
+## Post-merge actions (not part of this plan, but called out in the spec)
+
+After the PR merges:
+
+1. Post a comment on issue #59 summarizing what shipped (six new knobs and their defaults) and naming the deferred follow-ons (C1 materialized warm-set, C2 dump export, C4 replica routing). **Keep the issue open** as the tracking thread for those structural plays.
+2. Validate the change on aaf-prod by observing primary CPU during the next rolling deploy. Expected: the prior 90+% CPU spike replaced by a sustained ~30% baseline lasting ~45s.
+
+---
+
+## Self-review notes
+
+This plan was self-reviewed against the spec:
+
+- **Spec coverage:** A1 (Task 2), A2 (Task 2), A3 (Task 3), B2b (Tasks 4-7), config plumbing (Tasks 8-9), error handling (covered in Tasks 5, 7, with per-batch error handling in Task 3), observability (Tasks 5, 8), integration tests (Tasks 10-12), changelog (Task 13). All sections of the spec have a corresponding task.
+- **Placeholder scan:** none. Every step has exact code, exact paths, exact commands.
+- **Type consistency:** `_acquire_slot()` returns `tuple[Connection, int] | None`; `_release_slot(lock_conn, slot)` signature consistent; module-level constants `WARMER_LOCK_NS` and `WARMER_SLOT_BASE` used identically in tests and source.
+- **One open question for the implementer:** the `_LockCursor` in Task 4's helper uses tuple results (positional indexing `row[0]`). The dedicated lock connection in `_acquire_slot` is opened via `psycopg.connect(self._dsn, autocommit=True)` without `row_factory=dict_row` — confirmed in `startup_locks.py`. Production code matches test expectations.

--- a/docs/superpowers/specs/2026-05-29-cache-warmer-herd-mitigation-design.md
+++ b/docs/superpowers/specs/2026-05-29-cache-warmer-herd-mitigation-design.md
@@ -1,0 +1,248 @@
+# Cache warmer herd mitigation — design
+
+**Date:** 2026-05-29
+**Status:** brainstormed, awaiting implementation plan
+**Issue:** [#59](https://github.com/bluedynamics/zodb-pgjsonb/issues/59) — Cache warmer thundering herd on rolling deploys
+**Scope:** smear and cap the inter-pod DB load that `CacheWarmer.warm()` produces during rolling Kubernetes deployments. Bundle: per-pod startup delay + jitter (A1+A2), paced batched warmup (A3), and a PG-advisory-lock semaphore that caps cluster-wide concurrent warmers (B2b).
+
+## Problem recap
+
+On every pod startup, `PGJsonbStorage.__init__` spawns a daemon thread that runs `CacheWarmer.warm()`. The warmer issues a single `SELECT ... WHERE zoid = ANY(...)` against `object_state` for ~`target` rows (default `cache_warm_pct=10`% of the per-connection cache budget, ~8800 rows on the production site).
+
+The query itself is fine. The pain is that **N pods do this independently within a tight rolling-deploy window** (~30s), so the primary DB sees N× the qps for the same hot rows with no per-pod additional benefit. Observed: 6 pods × ~1700 qps each = ~10 kqps on a DB whose baseline is ~100 qps, pushing primary CPU from baseline ~10% to 90+%.
+
+Already mitigated by prior work:
+
+- [#63 / 1.12.0](https://github.com/bluedynamics/zodb-pgjsonb/pull/66) — `SharedLoadCache` eliminated intra-pod cache duplication. Each pod now warms one process-wide cache instead of K per-connection caches.
+- [#65 / 1.12.1](https://github.com/bluedynamics/zodb-pgjsonb/pull/68) — warmer hardening: consensus-TID race recovery, `current_max_tid` consolidation.
+- [#57 / 1.10.4](https://github.com/bluedynamics/zodb-pgjsonb/pull/55) — `startup_locks.py` introduced the **PG advisory lock** primitive we reuse here.
+
+Issue [#59 idea #3](https://github.com/bluedynamics/zodb-pgjsonb/issues/59) (opt-out knob) is already implemented as `cache-warm-pct=0`.
+
+What is **not** yet mitigated: inter-pod simultaneity. That is the scope of this design.
+
+## Goals
+
+1. **Smear the warmer load across pods** so a rolling deploy doesn't produce a synchronous burst.
+2. **Move the warmer's DB work out of each pod's own cold-start window**, so it doesn't compete with Plone import + `plone.pgcatalog` schema-check + `ANALYZE object_state` chatter on the same connection pool.
+3. **Lower the per-pod peak qps** so even worst-case alignment after smear-out doesn't saturate.
+4. **Cap cluster-wide concurrent warmers** so very large fleets (12+ pods) still don't stack on the primary.
+
+Non-goals (deferred to a later release):
+
+- Eliminating the per-pod DB cost structurally (e.g., materialized warm-set table, peer-to-peer warming, replica routing).
+- A real readiness-signal handshake with the embedder (Plone/Zope). The "delay" knob here is a fixed-time approximation; a real handshake is a 1.13+ story.
+- Cross-pod warm-data transfer.
+
+## Design
+
+Four composable behaviors added to `CacheWarmer.warm()`. Each is independently configurable; all default to "on but conservative". The pacing and semaphore can be effectively disabled by setting their knobs to extreme values (concurrency = very large, batch pause = 0).
+
+### A2 — Baseline startup delay
+
+The warmer thread sleeps `cache_warm_delay` seconds before doing **anything else** (no `SELECT`, no lock acquisition).
+
+- **Purpose:** get the warmer's DB queries out of the pod's own cold-start window, where Plone is still importing, `plone.pgcatalog` is doing its schema-check, and `ANALYZE object_state` is firing on the same connection pool.
+- **Default:** 15 seconds.
+- **Rationale:** observed Plone cold-start storm typically winds down by T+10–20s on a healthy pod. 15s is a conservative midpoint.
+
+### A1 — Jitter on top of the baseline
+
+After the baseline `cache_warm_delay`, the warmer additionally sleeps `random.uniform(0, cache_warm_jitter)` seconds before proceeding.
+
+- **Purpose:** spread the lock-acquisition arrivals across pods so they don't collide on the lock function.
+- **Default:** 30 seconds.
+- **Rationale:** with 6 pods booting in ~30s, a 0-30s uniform jitter spreads lock arrivals over the full deploy window. The semaphore (B2b) handles concurrency *after* arrival; jitter just keeps arrivals clean.
+
+Conceptually `A2 + A1` is `random.uniform(delay, delay + jitter)` — single `time.sleep` call, two knobs.
+
+### B2b — N-slot PG-advisory-lock semaphore with wait-on-miss
+
+After the A2+A1 sleep, the warmer tries to acquire a slot:
+
+```python
+for slot in range(1, concurrency + 1):
+    if pg_try_advisory_lock(WARMER_LOCK_NS, slot):
+        # got slot; warm
+        break
+else:
+    # all slots taken
+    sleep random.uniform(2, 5); retry
+    # bounded by cache_warm_wait_max; on expiry skip + WARNING
+```
+
+- **Slot keyspace:** `WARMER_LOCK_NS = 0x5A4442` (`"ZDB"`, same namespace as startup DDL), `slot ∈ {1..N}`. Distinct from the existing `STARTUP_DDL_LOCK_KEY = 1`; reserve `slot ∈ {100..199}` for the warmer to leave room for future lock kinds.
+- **Lock connection lifecycle:** mirror `startup_locks.py` — dedicated `psycopg.connect(dsn, autocommit=True)` for the warmer's lock. Session-level lock auto-releases on connection close, so a pod crash mid-warm safely frees the slot.
+- **Default concurrency:** 2.
+  - Rationale: small enough to keep DB headroom; large enough to cover the common 4–8 pod fleet without unreasonable last-pod latency.
+- **Default wait cap:** 300s (5 min).
+  - On expiry: skip warming, log WARNING, return (the daemon thread terminates).
+- **Retry sleep:** `random.uniform(2, 5)` seconds between attempts. Jittered to prevent retry stampedes.
+
+### A3 — Paced batched warmup
+
+`CacheWarmer.warm()` currently issues a single `SELECT ... WHERE zoid = ANY(...)` for the full `target` set, materializing the entire result in one round trip. Change to batched fetches:
+
+```python
+batch_size = cache_warm_batch_size           # default 500
+batch_pause = cache_warm_batch_pause         # default 0.5 seconds
+for chunk in chunked(top_zoids, batch_size):
+    results = load_multiple_fn(chunk_p64)
+    for oid, (data, tid_bytes) in results.items():
+        shared_cache.set(...)
+    time.sleep(batch_pause)
+```
+
+- **Purpose:** lower per-pod peak qps. Instead of one big burst, the load is spread over `(target / batch_size) × batch_pause` seconds.
+  - With defaults: 8800 / 500 × 0.5s ≈ 9s of work for one pod.
+- **Defaults:** batch_size=500, batch_pause=0.5s.
+- **Trade-off:** longer per-pod warmup duration (9s vs ~5s today) but lower peak qps and less interference with concurrent activity on the connection pool.
+- **Edge:** small `target` (< batch_size) → one batch, no inter-batch sleep needed (skip the trailing `time.sleep`).
+
+### Composed flow
+
+```
+storage init
+   │
+   ├─ spawn daemon thread "zodb-cache-warmer"
+   │
+   └─ daemon thread:
+        1. sleep cache_warm_delay + random(0, cache_warm_jitter)        ← A2 + A1
+        2. open dedicated PG conn for lock holding
+        3. loop:                                                         ← B2b
+             for slot in 1..N:
+                 if pg_try_advisory_lock(WARMER_NS, 100+slot):
+                     break
+             else:
+                 if waited > cache_warm_wait_max: log WARN + return
+                 sleep random(2, 5); retry
+        4. read top-N zoids from cache_warm_stats
+        5. prime consensus_tid (existing code path)
+        6. for chunk in chunked(top_zoids, batch_size):                  ← A3
+               results = load_multiple_fn(chunk)
+               for each result: shared_cache.set(...)
+               if not last chunk: sleep batch_pause
+        7. release lock (or rely on connection close)
+        8. close dedicated PG conn
+```
+
+## Components
+
+### `src/zodb_pgjsonb/cache_warmer.py`
+
+- `CacheWarmer.__init__` gains: `delay`, `jitter`, `concurrency`, `wait_max`, `batch_size`, `batch_pause` parameters with the defaults above. Also a `dsn` parameter (needed to open the dedicated lock connection — the warmer's existing `conn` is the main storage connection and is the wrong scope for a session-level lock).
+- `CacheWarmer.warm()` orchestrates the new flow as shown above. The existing primer-consensus logic is preserved in step 5.
+- A new private helper `CacheWarmer._acquire_slot()` returns `(conn, slot)` or `None` on timeout. Wraps the dedicated-connection open, the slot-retry loop, and the WARNING log on timeout.
+- A new private helper `CacheWarmer._release_slot(conn, slot)` releases the lock and closes the connection.
+
+### `src/zodb_pgjsonb/storage.py`
+
+- `PGJsonbStorage.__init__` reads the six new config values from kwargs and forwards them to `CacheWarmer(...)`. Also passes `dsn=self._dsn` so the warmer can open its own lock connection.
+- Existing daemon-thread spawn stays as-is (`threading.Thread(target=self._warmer.warm, ...)`). All new behavior lives inside `warm()`.
+
+### `src/zodb_pgjsonb/component.xml` + `src/zodb_pgjsonb/config.py`
+
+Six new ZConfig keys (all `default` values per A1/A2/A3/B2b above):
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `cache-warm-delay` | integer (seconds) | 15 | Baseline sleep before warmer starts. Moves warmer out of the pod's own cold-start window. Set to 0 to disable. |
+| `cache-warm-jitter` | integer (seconds) | 30 | Additional `random(0, jitter)` sleep on top of `cache-warm-delay`. Spreads warmer arrivals across pods. Set to 0 to disable. |
+| `cache-warm-concurrency` | integer | 2 | Maximum number of pods warming concurrently in the cluster (enforced via PG advisory locks). Set to a very high value to effectively disable the cap. |
+| `cache-warm-wait-max` | integer (seconds) | 300 | If all slots are taken, wait at most this long before skipping. On skip, log a WARNING. |
+| `cache-warm-batch-size` | integer | 500 | Number of zoids fetched per `SELECT` batch. |
+| `cache-warm-batch-pause` | float (seconds) | 0.5 | Sleep between batches. Lowers per-pod peak qps. Set to 0 to disable. |
+
+`config.py` maps these via `getattr(config, "cache_warm_X", default)`, following the existing pattern for `cache_warm_pct` and `cache_warm_decay`.
+
+### Lock namespace
+
+Constants in `cache_warmer.py` (not `startup_locks.py` — different concern, different lifetime):
+
+```python
+WARMER_LOCK_NS = 0x5A4442   # shared "ZDB" namespace
+WARMER_SLOT_BASE = 100      # slot keys are WARMER_SLOT_BASE + i for i in 1..concurrency
+```
+
+The slot keys start at 100 to leave a clear gap from `STARTUP_DDL_LOCK_KEY = 1`. There is no hard upper bound — operators who set `cache-warm-concurrency=9999` simply use keys `101..10099`. Future lock kinds should pick a base well above the largest expected `concurrency` (e.g., `100_000+`).
+
+## Error handling
+
+- **Lock connection fails to open** (DSN issue, PG down, pool exhausted) — log WARNING, skip warming, daemon thread exits. No retries — if the DB is unhealthy, the warmer should not pile on.
+- **All slots taken until `cache_warm_wait_max` expires** — log WARNING with the wait duration and pod identity hint (logger name + thread name suffice), skip warming, release the dedicated connection.
+- **`pg_try_advisory_lock` raises** during the retry loop — treat as a slot-miss for that iteration; the next retry opens a fresh connection if needed.
+- **Warming itself raises after slot acquired** — existing `try/except` around `load_multiple_fn(chunk)` is extended to the batch loop. On any chunk failure: log WARNING, release the slot, close the lock connection, return from `warm()` (the daemon thread terminates). Do not retry; recording-phase stats will pick up the missing zoids on next boot anyway.
+- **`pg_advisory_unlock` raises on release** — log WARNING; close the connection regardless. PG auto-releases session locks on connection close.
+
+## Observability
+
+- Existing INFO log `Cache warmer started (target=%d, decay=%.1f)` extended to include the new parameters' effective values.
+- New INFO log on slot acquisition: `"Cache warmer: acquired slot %d after %.1fs wait"`.
+- New INFO log on retry: `"Cache warmer: all %d slots taken, retrying (waited %.1fs so far)"` — logged on every retry. Cheap and operators want to see this.
+- New WARNING on timeout: `"Cache warmer: gave up after %.1fs waiting for slot, skipping warmup"`.
+- Existing INFO log on completion extended with elapsed time: `"Cache warmer: loaded %d of %d objects into shared cache in %.1fs (%d batches)"`.
+
+## Testing
+
+Following the existing test style (`tests/test_cache_warmer.py`, `tests/test_shared_load_cache.py`):
+
+### Unit tests (no DB needed)
+
+- A2+A1 delay sleep is called with `delay + random(0, jitter)` — assert with a mocked `time.sleep`.
+- A3 batching: `target=1100, batch_size=500` produces 3 batches with 2 inter-batch sleeps of `batch_pause`. Last batch does not sleep.
+- B2b retry logic: mock `pg_try_advisory_lock` to return False for slots 1..N, True only after K retries; assert K-1 retries occurred, K slot-attempts logged, and warming proceeds.
+- B2b timeout: `pg_try_advisory_lock` always False; assert warmer exits after `wait_max`, WARNING logged, no warming performed.
+- Lock-connection-open failure: `psycopg.connect` raises; assert WARNING logged, no warming, no crash.
+
+### Integration tests (DB-marked, `@pytest.mark.db`)
+
+- **Slot acquisition end-to-end:** two `CacheWarmer` instances in parallel threads against a real PG with `concurrency=1`; assert serialized warming (one finishes before the other starts).
+- **Concurrency=N:** N+1 warmers, `concurrency=N`; assert N warm in parallel and the (N+1)th waits then warms.
+- **Crash-safe lock release:** start a warmer, kill its lock connection mid-warm; assert another warmer can acquire the slot.
+- **Existing warmup regression tests** (consensus-TID race, set acceptance, recording → flush → top-N read) continue to pass.
+
+### Performance smoke test (manual, documented in CHANGES)
+
+- 6-pod local simulation (6 processes via shell loop, each instantiating `PGJsonbStorage`): measure peak qps against a local PG with `pg_stat_activity` / `pg_stat_statements`. Compare to baseline (all knobs disabled). Expected: peak qps drops by roughly `concurrency / N_pods` and is spread over `delay + jitter + warmup_duration` seconds instead of a 5s burst.
+
+## Migration / compatibility
+
+- All new config keys have defaults; existing deployments get the new behavior automatically.
+- The new defaults are conservative but **do change observable behavior**: existing deployments will see warmer queries delayed by ~15-45s post-startup. Document this prominently in the CHANGES entry.
+- For deployments that want the pre-1.12.x behavior (immediate, unbatched, uncoordinated) — set `cache-warm-delay=0`, `cache-warm-jitter=0`, `cache-warm-batch-pause=0`, `cache-warm-concurrency=9999`. Document this escape hatch.
+- No DB schema changes. No new tables. The advisory lock keys are transient.
+
+## Last-pod latency analysis (for the CHANGES note)
+
+Worst-case time-to-warm for the last pod in a rolling deploy:
+
+```
+T_last = cache_warm_delay
+       + ceil(N_pods / cache_warm_concurrency) × warmup_duration
+       + retry_jitter_average
+```
+
+Where `warmup_duration ≈ (target / batch_size) × batch_pause`.
+
+For the production scenario (N=6, concurrency=2, target=8800, batch_size=500, batch_pause=0.5):
+
+```
+warmup_duration ≈ 18 × 0.5s = 9s
+T_last ≈ 15s + ceil(6/2) × 9s + ~3s = ~45s
+```
+
+That's ~45s before the last pod has a warm cache. Pod is already serving traffic from T+0; warmer is daemon. So this is "time until all pods have a warm L2", not "time until pods are serving".
+
+## Open questions
+
+None outstanding for this scope. The bigger architectural plays (materialized warm-set table, peer-to-peer warming, replica routing) are explicitly deferred and tracked separately.
+
+## Issue lifecycle
+
+[#59](https://github.com/bluedynamics/zodb-pgjsonb/issues/59) stays **open** after this work merges. On merge, post a comment on the issue summarizing what was shipped (A1+A2+A3+B2b knobs and their defaults) and naming the deferred follow-ons (C1 materialized warm-set, C2 dump export, C4 replica routing). The issue remains the tracking thread for the bigger structural plays.
+
+## References
+
+- Issue: [#59](https://github.com/bluedynamics/zodb-pgjsonb/issues/59)
+- Prior art: [`src/zodb_pgjsonb/startup_locks.py`](../../../src/zodb_pgjsonb/startup_locks.py) — PG advisory lock pattern reused here.
+- Related changes: #63 (SharedLoadCache), #65 (warmer hardening), #57 (startup DDL lock)

--- a/src/zodb_pgjsonb/cache_warmer.py
+++ b/src/zodb_pgjsonb/cache_warmer.py
@@ -25,6 +25,11 @@ CREATE TABLE IF NOT EXISTS cache_warm_stats (
 );
 """
 
+# Advisory-lock keyspace for B2b inter-pod warmer semaphore (#59).
+# Same namespace as startup_locks.py (separate keys).
+WARMER_LOCK_NS = 0x5A4442    # "ZDB"
+WARMER_SLOT_BASE = 100       # slot keys are WARMER_SLOT_BASE + i for i in 1..N
+
 
 class CacheWarmer:
     """Learning cache warmer.
@@ -127,6 +132,35 @@ class CacheWarmer:
             with contextlib.suppress(Exception):
                 self._conn.execute("ROLLBACK")
             log.warning("Cache warmer: flush failed", exc_info=True)
+
+    # ── B2b slot acquisition (#59) ───────────────────────────────────
+
+    def _try_acquire_slot_once(self, lock_conn):
+        """Try each slot 1..concurrency once.  Returns the acquired
+        slot number, or None if all slots are taken.
+
+        ``lock_conn`` must be an autocommit psycopg connection
+        dedicated to holding the session-level advisory lock.
+        """
+        for slot in range(1, self._concurrency + 1):
+            key = WARMER_SLOT_BASE + slot
+            try:
+                with lock_conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT pg_try_advisory_lock(%s, %s)",
+                        (WARMER_LOCK_NS, key),
+                    )
+                    row = cur.fetchone()
+            except Exception:
+                log.warning(
+                    "Cache warmer: pg_try_advisory_lock raised for slot %d",
+                    slot,
+                    exc_info=True,
+                )
+                return None
+            if row and row[0]:
+                return slot
+        return None
 
     # ── Warming phase ────────────────────────────────────────────────
 

--- a/src/zodb_pgjsonb/cache_warmer.py
+++ b/src/zodb_pgjsonb/cache_warmer.py
@@ -177,17 +177,6 @@ class CacheWarmer:
             log.warning("Cache warmer: could not read current TID, skipping warmup")
             return
 
-        oids = [p64(z) for z in top_zoids]
-        try:
-            results = load_multiple_fn(oids)
-        except Exception:
-            log.warning("Cache warmer: load_multiple failed", exc_info=True)
-            return
-
-        if not results:
-            log.info("Cache warmer: load_multiple returned no objects")
-            return
-
         # Prime consensus so set() accepts our writes.  Another instance
         # may have advanced consensus beyond our sampled current_tid
         # already — in that case poll_advance is a no-op, and the actual
@@ -200,17 +189,42 @@ class CacheWarmer:
             log.warning("Cache warmer: consensus still None after poll_advance")
             return
 
+        # A3 (#59): batch the fetches and pause between them so a single
+        # pod's warmup doesn't burst the connection pool / DB CPU.
+        batch_size = max(1, self._batch_size)
+        batches = [
+            top_zoids[i:i + batch_size]
+            for i in range(0, len(top_zoids), batch_size)
+        ]
         written = 0
         attempted = 0
-        for oid, (data, tid_bytes) in results.items():
-            attempted += 1
-            if self._shared_cache.set(
-                zoid=u64(oid),
-                data=data,
-                tid_bytes=tid_bytes,
-                polled_tid=effective_tid,
-            ):
-                written += 1
+        for batch_idx, batch in enumerate(batches):
+            oids = [p64(z) for z in batch]
+            try:
+                results = load_multiple_fn(oids)
+            except Exception:
+                log.warning(
+                    "Cache warmer: load_multiple failed at batch %d/%d",
+                    batch_idx + 1, len(batches),
+                    exc_info=True,
+                )
+                return
+            for oid, (data, tid_bytes) in results.items():
+                attempted += 1
+                if self._shared_cache.set(
+                    zoid=u64(oid),
+                    data=data,
+                    tid_bytes=tid_bytes,
+                    polled_tid=effective_tid,
+                ):
+                    written += 1
+            # Pause only between batches, never after the last.
+            if batch_idx < len(batches) - 1 and self._batch_pause > 0:
+                time.sleep(self._batch_pause)
+
+        if attempted == 0:
+            log.info("Cache warmer: load_multiple returned no objects")
+            return
 
         if written == 0:
             log.warning(
@@ -223,7 +237,9 @@ class CacheWarmer:
             )
         else:
             log.info(
-                "Cache warmer: loaded %d of %d objects into shared cache",
+                "Cache warmer: loaded %d of %d objects into shared cache "
+                "(%d batches)",
                 written,
                 attempted,
+                len(batches),
             )

--- a/src/zodb_pgjsonb/cache_warmer.py
+++ b/src/zodb_pgjsonb/cache_warmer.py
@@ -11,10 +11,9 @@ the shared-cache migration.
 
 import contextlib
 import logging
+import psycopg
 import random
 import time
-
-import psycopg
 
 
 log = logging.getLogger(__name__)
@@ -29,8 +28,8 @@ CREATE TABLE IF NOT EXISTS cache_warm_stats (
 
 # Advisory-lock keyspace for B2b inter-pod warmer semaphore (#59).
 # Same namespace as startup_locks.py (separate keys).
-WARMER_LOCK_NS = 0x5A4442    # "ZDB"
-WARMER_SLOT_BASE = 100       # slot keys are WARMER_SLOT_BASE + i for i in 1..N
+WARMER_LOCK_NS = 0x5A4442  # "ZDB"
+WARMER_SLOT_BASE = 100  # slot keys are WARMER_SLOT_BASE + i for i in 1..N
 
 
 class CacheWarmer:
@@ -197,9 +196,10 @@ class CacheWarmer:
                 if slot is not None:
                     waited = time.monotonic() - started
                     log.info(
-                        "Cache warmer: acquired slot %d after %.1fs wait "
-                        "(attempt %d)",
-                        slot, waited, attempt,
+                        "Cache warmer: acquired slot %d after %.1fs wait (attempt %d)",
+                        slot,
+                        waited,
+                        attempt,
                     )
                     return lock_conn, slot
 
@@ -208,14 +208,15 @@ class CacheWarmer:
                     log.warning(
                         "Cache warmer: gave up after %.1fs waiting for slot "
                         "(%d attempts), skipping warmup",
-                        waited, attempt,
+                        waited,
+                        attempt,
                     )
                     return None
 
                 log.info(
-                    "Cache warmer: all %d slots taken, retrying "
-                    "(waited %.1fs so far)",
-                    self._concurrency, waited,
+                    "Cache warmer: all %d slots taken, retrying (waited %.1fs so far)",
+                    self._concurrency,
+                    waited,
                 )
                 time.sleep(random.uniform(2.0, 5.0))
         except Exception:
@@ -335,8 +336,7 @@ class CacheWarmer:
         # pod's warmup doesn't burst the connection pool / DB CPU.
         batch_size = max(1, self._batch_size)
         batches = [
-            top_zoids[i:i + batch_size]
-            for i in range(0, len(top_zoids), batch_size)
+            top_zoids[i : i + batch_size] for i in range(0, len(top_zoids), batch_size)
         ]
         written = 0
         attempted = 0
@@ -347,7 +347,8 @@ class CacheWarmer:
             except Exception:
                 log.warning(
                     "Cache warmer: load_multiple failed at batch %d/%d",
-                    batch_idx + 1, len(batches),
+                    batch_idx + 1,
+                    len(batches),
                     exc_info=True,
                 )
                 return
@@ -379,8 +380,7 @@ class CacheWarmer:
             )
         else:
             log.info(
-                "Cache warmer: loaded %d of %d objects into shared cache "
-                "(%d batches)",
+                "Cache warmer: loaded %d of %d objects into shared cache (%d batches)",
                 written,
                 attempted,
                 len(batches),

--- a/src/zodb_pgjsonb/cache_warmer.py
+++ b/src/zodb_pgjsonb/cache_warmer.py
@@ -42,8 +42,15 @@ class CacheWarmer:
         target_count,
         shared_cache,
         load_current_tid_fn,
+        dsn=None,
         decay=0.8,
         flush_interval=1000,
+        delay=0,
+        jitter=0,
+        concurrency=0,
+        wait_max=300,
+        batch_size=500,
+        batch_pause=0.0,
     ):
         self.recording = target_count > 0
         self._recorded = set()
@@ -58,6 +65,17 @@ class CacheWarmer:
         self._load_current_tid_fn = load_current_tid_fn
 
         self._conn = conn
+
+        # Herd-mitigation knobs (#59).  CacheWarmer defaults are off
+        # so direct instantiation in tests preserves prior behavior;
+        # PGJsonbStorage / ZConfig set the production defaults.
+        self._dsn = dsn
+        self._delay = delay
+        self._jitter = jitter
+        self._concurrency = concurrency
+        self._wait_max = wait_max
+        self._batch_size = batch_size
+        self._batch_pause = batch_pause
 
     # ── Recording phase ──────────────────────────────────────────────
 

--- a/src/zodb_pgjsonb/cache_warmer.py
+++ b/src/zodb_pgjsonb/cache_warmer.py
@@ -11,6 +11,8 @@ the shared-cache migration.
 
 import contextlib
 import logging
+import random
+import time
 
 
 log = logging.getLogger(__name__)
@@ -156,6 +158,12 @@ class CacheWarmer:
         likely sign of the race being wider than this mitigation
         covers).
         """
+        # A2 + A1 (#59): get out of the pod's own cold-start window and
+        # smear lock-arrival times across pods so the cluster doesn't
+        # stampede the primary on rolling deploys.
+        if self._delay > 0 or self._jitter > 0:
+            time.sleep(self._delay + random.uniform(0, self._jitter))
+
         from ZODB.utils import p64
         from ZODB.utils import u64
 

--- a/src/zodb_pgjsonb/cache_warmer.py
+++ b/src/zodb_pgjsonb/cache_warmer.py
@@ -265,25 +265,47 @@ class CacheWarmer:
     def warm(self, load_multiple_fn):
         """Load top-N ZOIDs into the shared cache.
 
-        Runs in a background daemon thread.  Primes the consensus TID
-        on the shared cache to the current PG max_tid so that
-        subsequent ``shared.set`` calls are accepted.  Re-reads
-        consensus after ``poll_advance`` and uses that as the
-        ``polled_tid`` for set calls — this is the mitigation for the
-        startup race where an instance's poll advances consensus past
-        the warmer's sampled TID before the set loop begins.
-
-        Skips warmup when the TID is unavailable.  Logs a WARNING when
-        every set() was rejected despite a non-empty result set (a
-        likely sign of the race being wider than this mitigation
-        covers).
+        Runs in a background daemon thread.  Orchestrates the four
+        herd-mitigation phases (#59): startup delay + jitter (A2+A1),
+        cluster-wide slot acquisition (B2b), paced batched warmup (A3),
+        slot release.
         """
-        # A2 + A1 (#59): get out of the pod's own cold-start window and
+        # A2 + A1: get out of the pod's own cold-start window and
         # smear lock-arrival times across pods so the cluster doesn't
         # stampede the primary on rolling deploys.
         if self._delay > 0 or self._jitter > 0:
             time.sleep(self._delay + random.uniform(0, self._jitter))
 
+        # B2b: try to claim one of N cluster-wide slots.  When
+        # concurrency is 0 the semaphore is disabled.
+        lock_conn = None
+        slot = None
+        if self._concurrency >= 1:
+            acquired = self._acquire_slot()
+            if acquired is None:
+                # Already logged inside _acquire_slot (timeout or open failure).
+                return
+            lock_conn, slot = acquired
+
+        try:
+            self._warm_body(load_multiple_fn)
+        finally:
+            if lock_conn is not None:
+                self._release_slot(lock_conn, slot)
+
+    def _warm_body(self, load_multiple_fn):
+        """Top-OID read + prime-consensus + paced batched load+set.
+
+        Primes the consensus TID on the shared cache to the current PG
+        max_tid so that subsequent ``shared.set`` calls are accepted.
+        Re-reads consensus after ``poll_advance`` and uses that as the
+        ``polled_tid`` for set calls — this is the mitigation for the
+        startup race where an instance's poll advances consensus past
+        the warmer's sampled TID before the set loop begins.
+
+        Skips warmup when the TID is unavailable.  Logs a WARNING when
+        every set() was rejected despite a non-empty result set.
+        """
         from ZODB.utils import p64
         from ZODB.utils import u64
 

--- a/src/zodb_pgjsonb/cache_warmer.py
+++ b/src/zodb_pgjsonb/cache_warmer.py
@@ -227,6 +227,27 @@ class CacheWarmer:
                 lock_conn.close()
             return None
 
+    def _release_slot(self, lock_conn, slot):
+        """Release the advisory lock and close the dedicated connection.
+
+        Errors are logged and suppressed — PG auto-releases session
+        locks on connection close, so a failed unlock is recoverable.
+        """
+        key = WARMER_SLOT_BASE + slot
+        try:
+            lock_conn.execute(
+                "SELECT pg_advisory_unlock(%s, %s)",
+                (WARMER_LOCK_NS, key),
+            )
+        except Exception:
+            log.warning(
+                "Cache warmer: pg_advisory_unlock failed for slot %d",
+                slot,
+                exc_info=True,
+            )
+        with contextlib.suppress(Exception):
+            lock_conn.close()
+
     # ── Warming phase ────────────────────────────────────────────────
 
     def _read_top_oids(self):

--- a/src/zodb_pgjsonb/cache_warmer.py
+++ b/src/zodb_pgjsonb/cache_warmer.py
@@ -153,12 +153,15 @@ class CacheWarmer:
                     )
                     row = cur.fetchone()
             except Exception:
+                # Per-slot transient error: log and treat as miss.  The
+                # outer retry loop in _acquire_slot will reopen the
+                # connection if it's truly dead.
                 log.warning(
                     "Cache warmer: pg_try_advisory_lock raised for slot %d",
                     slot,
                     exc_info=True,
                 )
-                return None
+                continue
             if row and row[0]:
                 return slot
         return None
@@ -211,6 +214,8 @@ class CacheWarmer:
                         waited,
                         attempt,
                     )
+                    with contextlib.suppress(Exception):
+                        lock_conn.close()
                     return None
 
                 log.info(

--- a/src/zodb_pgjsonb/cache_warmer.py
+++ b/src/zodb_pgjsonb/cache_warmer.py
@@ -14,6 +14,8 @@ import logging
 import random
 import time
 
+import psycopg
+
 
 log = logging.getLogger(__name__)
 
@@ -161,6 +163,69 @@ class CacheWarmer:
             if row and row[0]:
                 return slot
         return None
+
+    def _acquire_slot(self):
+        """Acquire one of ``concurrency`` cluster-wide slots.
+
+        Opens a dedicated autocommit psycopg connection and tries each
+        slot via ``_try_acquire_slot_once`` in a retry loop.  Returns
+        ``(lock_conn, slot)`` on success or ``None`` on timeout / open
+        failure.
+
+        Caller is responsible for releasing the slot and closing the
+        connection (see ``_release_slot``).  Session-level advisory
+        locks auto-release on connection close, so a pod crash mid-warm
+        safely frees the slot.
+        """
+        if self._dsn is None or self._concurrency < 1:
+            return None
+        try:
+            lock_conn = psycopg.connect(self._dsn, autocommit=True)
+        except Exception:
+            log.warning(
+                "Cache warmer: failed to open lock connection, skipping warmup",
+                exc_info=True,
+            )
+            return None
+
+        started = time.monotonic()
+        attempt = 0
+        try:
+            while True:
+                attempt += 1
+                slot = self._try_acquire_slot_once(lock_conn)
+                if slot is not None:
+                    waited = time.monotonic() - started
+                    log.info(
+                        "Cache warmer: acquired slot %d after %.1fs wait "
+                        "(attempt %d)",
+                        slot, waited, attempt,
+                    )
+                    return lock_conn, slot
+
+                waited = time.monotonic() - started
+                if waited >= self._wait_max:
+                    log.warning(
+                        "Cache warmer: gave up after %.1fs waiting for slot "
+                        "(%d attempts), skipping warmup",
+                        waited, attempt,
+                    )
+                    return None
+
+                log.info(
+                    "Cache warmer: all %d slots taken, retrying "
+                    "(waited %.1fs so far)",
+                    self._concurrency, waited,
+                )
+                time.sleep(random.uniform(2.0, 5.0))
+        except Exception:
+            log.warning(
+                "Cache warmer: unexpected error in slot acquisition",
+                exc_info=True,
+            )
+            with contextlib.suppress(Exception):
+                lock_conn.close()
+            return None
 
     # ── Warming phase ────────────────────────────────────────────────
 

--- a/src/zodb_pgjsonb/component.xml
+++ b/src/zodb_pgjsonb/component.xml
@@ -95,6 +95,57 @@
       </description>
     </key>
 
+    <key name="cache-warm-delay" datatype="integer" default="15">
+      <description>
+        Baseline sleep (seconds) before the cache warmer starts work.
+        Moves the warmer out of the pod's own cold-start window so it
+        does not compete with Plone import + plone.pgcatalog schema
+        checks + ANALYZE chatter.  Set to 0 to disable.  Default: 15.
+        See issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-jitter" datatype="integer" default="30">
+      <description>
+        Additional uniform-random sleep (0..jitter seconds) on top of
+        cache-warm-delay.  Spreads warmer arrival times across pods so
+        a rolling deploy does not produce a synchronous DB burst.  Set
+        to 0 to disable.  Default: 30.  See issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-concurrency" datatype="integer" default="2">
+      <description>
+        Maximum number of pods warming concurrently in the cluster,
+        enforced via PostgreSQL advisory locks.  Set to a very large
+        value (e.g. 9999) to effectively disable the cap.  Default: 2.
+        See issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-wait-max" datatype="integer" default="300">
+      <description>
+        Maximum time (seconds) to wait for a free slot before giving
+        up and skipping warmup (logs a WARNING).  Default: 300.  See
+        issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-batch-size" datatype="integer" default="500">
+      <description>
+        Number of ZOIDs fetched per SELECT batch during warmup.  Lower
+        values reduce peak qps at the cost of longer warmup duration.
+        Default: 500.  See issue #59.
+      </description>
+    </key>
+
+    <key name="cache-warm-batch-pause" datatype="float" default="0.5">
+      <description>
+        Sleep (seconds) between warmup batches.  Lowers per-pod peak
+        qps.  Set to 0 to disable.  Default: 0.5.  See issue #59.
+      </description>
+    </key>
+
     <!-- S3 tiered blob storage (optional, requires zodb-pgjsonb[s3]) -->
 
     <key name="blob-threshold" datatype="byte-size" default="100KB">

--- a/src/zodb_pgjsonb/config.py
+++ b/src/zodb_pgjsonb/config.py
@@ -80,6 +80,18 @@ class PGJsonbStorageFactory(BaseConfig):
             "blob_threshold": getattr(config, "blob_threshold", 100 * 1024),
             "cache_warm_pct": getattr(config, "cache_warm_pct", 10),
             "cache_warm_decay": getattr(config, "cache_warm_decay", 0.8),
+            "cache_warm_delay": getattr(config, "cache_warm_delay", 15),
+            "cache_warm_jitter": getattr(config, "cache_warm_jitter", 30),
+            "cache_warm_concurrency": getattr(
+                config, "cache_warm_concurrency", 2
+            ),
+            "cache_warm_wait_max": getattr(config, "cache_warm_wait_max", 300),
+            "cache_warm_batch_size": getattr(
+                config, "cache_warm_batch_size", 500
+            ),
+            "cache_warm_batch_pause": getattr(
+                config, "cache_warm_batch_pause", 0.5
+            ),
         }
         # Deprecation alias — let PGJsonbStorage.__init__ emit the warning
         if getattr(config, "cache_local_mb", None) is not None:

--- a/src/zodb_pgjsonb/config.py
+++ b/src/zodb_pgjsonb/config.py
@@ -82,16 +82,10 @@ class PGJsonbStorageFactory(BaseConfig):
             "cache_warm_decay": getattr(config, "cache_warm_decay", 0.8),
             "cache_warm_delay": getattr(config, "cache_warm_delay", 15),
             "cache_warm_jitter": getattr(config, "cache_warm_jitter", 30),
-            "cache_warm_concurrency": getattr(
-                config, "cache_warm_concurrency", 2
-            ),
+            "cache_warm_concurrency": getattr(config, "cache_warm_concurrency", 2),
             "cache_warm_wait_max": getattr(config, "cache_warm_wait_max", 300),
-            "cache_warm_batch_size": getattr(
-                config, "cache_warm_batch_size", 500
-            ),
-            "cache_warm_batch_pause": getattr(
-                config, "cache_warm_batch_pause", 0.5
-            ),
+            "cache_warm_batch_size": getattr(config, "cache_warm_batch_size", 500),
+            "cache_warm_batch_pause": getattr(config, "cache_warm_batch_pause", 0.5),
         }
         # Deprecation alias — let PGJsonbStorage.__init__ emit the warning
         if getattr(config, "cache_local_mb", None) is not None:

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -394,6 +394,12 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
         blob_threshold=102_400,
         cache_warm_pct=10,
         cache_warm_decay=0.8,
+        cache_warm_delay=15,
+        cache_warm_jitter=30,
+        cache_warm_concurrency=2,
+        cache_warm_wait_max=300,
+        cache_warm_batch_size=500,
+        cache_warm_batch_pause=0.5,
     ):
         BaseStorage.__init__(self, name)
         self._dsn = dsn
@@ -529,7 +535,14 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
                 target_count=target,
                 shared_cache=self._shared_cache,
                 load_current_tid_fn=self.current_max_tid,
+                dsn=self._dsn,
                 decay=cache_warm_decay,
+                delay=cache_warm_delay,
+                jitter=cache_warm_jitter,
+                concurrency=cache_warm_concurrency,
+                wait_max=cache_warm_wait_max,
+                batch_size=cache_warm_batch_size,
+                batch_pause=cache_warm_batch_pause,
             )
             import threading
 
@@ -540,9 +553,15 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
                 name="zodb-cache-warmer",
             ).start()
             logger.info(
-                "Cache warmer started (target=%d, decay=%.1f)",
+                "Cache warmer started (target=%d, decay=%.1f, delay=%ds, "
+                "jitter=%ds, concurrency=%d, batch_size=%d, batch_pause=%.2fs)",
                 target,
                 cache_warm_decay,
+                cache_warm_delay,
+                cache_warm_jitter,
+                cache_warm_concurrency,
+                cache_warm_batch_size,
+                cache_warm_batch_pause,
             )
 
         logger.debug("Storage initialized (max_oid=%s, ltid=%s)", self._oid, self._ltid)

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -606,6 +606,9 @@ class TestCacheWarmerSlot:
 
         # All slots permanently taken.
         lock_conn = self._make_lock_conn(slot_results=[False] * 100)
+        # Track that the lock connection is closed when timeout fires.
+        close_calls = []
+        lock_conn.close = lambda: close_calls.append(True)
 
         w = CacheWarmer(
             conn=mock.Mock(),
@@ -636,6 +639,8 @@ class TestCacheWarmerSlot:
             result = w._acquire_slot()
 
         assert result is None
+        # Connection must be closed on the timeout path (no leak).
+        assert close_calls == [True]
 
     def test_acquire_slot_handles_connect_failure(self):
         from zodb_pgjsonb.cache_warmer import CacheWarmer
@@ -876,18 +881,28 @@ class TestCacheWarmerDB:
             return {oid: (b"x", p64(50)) for oid in oids}
 
         def run_warmer():
-            w = CacheWarmer(
-                conn=self.conn,
-                target_count=10,
-                shared_cache=shared,
-                load_current_tid_fn=lambda: 100,
-                dsn=DSN,
-                concurrency=1,
-                wait_max=30,
-                batch_size=500,
-                batch_pause=0,
-            )
-            w.warm(slow_loader)
+            # Fresh connection per thread; psycopg connections are not
+            # thread-safe, and self.conn would otherwise be shared.
+            from psycopg.rows import dict_row
+
+            import psycopg
+
+            own_conn = psycopg.connect(DSN, autocommit=True, row_factory=dict_row)
+            try:
+                w = CacheWarmer(
+                    conn=own_conn,
+                    target_count=10,
+                    shared_cache=shared,
+                    load_current_tid_fn=lambda: 100,
+                    dsn=DSN,
+                    concurrency=1,
+                    wait_max=30,
+                    batch_size=500,
+                    batch_pause=0,
+                )
+                w.warm(slow_loader)
+            finally:
+                own_conn.close()
 
         t1 = threading.Thread(target=run_warmer)
         t2 = threading.Thread(target=run_warmer)
@@ -931,18 +946,28 @@ class TestCacheWarmerDB:
             return {oid: (b"x", p64(50)) for oid in oids}
 
         def run_warmer():
-            w = CacheWarmer(
-                conn=self.conn,
-                target_count=10,
-                shared_cache=shared,
-                load_current_tid_fn=lambda: 100,
-                dsn=DSN,
-                concurrency=2,
-                wait_max=30,
-                batch_size=500,
-                batch_pause=0,
-            )
-            w.warm(slow_loader)
+            # Fresh connection per thread (psycopg connections are not
+            # thread-safe).
+            from psycopg.rows import dict_row
+
+            import psycopg
+
+            own_conn = psycopg.connect(DSN, autocommit=True, row_factory=dict_row)
+            try:
+                w = CacheWarmer(
+                    conn=own_conn,
+                    target_count=10,
+                    shared_cache=shared,
+                    load_current_tid_fn=lambda: 100,
+                    dsn=DSN,
+                    concurrency=2,
+                    wait_max=30,
+                    batch_size=500,
+                    batch_pause=0,
+                )
+                w.warm(slow_loader)
+            finally:
+                own_conn.close()
 
         threads = [threading.Thread(target=run_warmer) for _ in range(3)]
         for t in threads:

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -361,6 +361,97 @@ class TestCacheWarmerWarm:
         assert shared._consensus_tid is None
         assert len(shared._cache) == 0
 
+    def test_warm_acquires_and_releases_slot(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+        )
+        # Pretend slot acquisition succeeds without touching PG.
+        acquire_calls = []
+        release_calls = []
+
+        def fake_acquire():
+            sentinel = object()
+            acquire_calls.append(sentinel)
+            return (sentinel, 1)
+
+        def fake_release(lock_conn, slot):
+            release_calls.append((lock_conn, slot))
+
+        w._acquire_slot = fake_acquire
+        w._release_slot = fake_release
+
+        def loader(oids):
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        w.warm(loader)
+        assert len(acquire_calls) == 1
+        assert len(release_calls) == 1
+        assert release_calls[0][1] == 1  # slot number
+        assert release_calls[0][0] is acquire_calls[0]  # same conn
+
+    def test_warm_skips_on_acquire_failure(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+        )
+        w._acquire_slot = lambda: None
+
+        load_called = []
+
+        def loader(oids):
+            load_called.append(oids)
+            return {}
+
+        w.warm(loader)
+        # No load when acquire fails.
+        assert load_called == []
+        assert len(shared._cache) == 0
+
+    def test_warm_no_slot_when_concurrency_zero(self):
+        """When concurrency=0, the slot path is bypassed entirely
+        (preserves backward-compat for direct test instantiation)."""
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            concurrency=0,
+        )
+        acquired = []
+        w._acquire_slot = lambda: acquired.append(True) or None
+
+        def loader(oids):
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        w.warm(loader)
+        # _acquire_slot must not be called when concurrency=0.
+        assert acquired == []
+        # Warming still happens.
+        assert len(shared._cache) == 2
+
     def test_warm_handles_load_multiple_exception(self):
         from zodb_pgjsonb.cache_warmer import CacheWarmer
         from zodb_pgjsonb.storage import SharedLoadCache

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -234,6 +234,59 @@ class TestCacheWarmerWarm:
         assert shared.get(zoid=2, polled_tid=100) == (b"data-" + p64(2), p64(50))
         assert shared.get(zoid=3, polled_tid=100) == (b"data-" + p64(3), p64(50))
 
+    def test_warm_sleeps_delay_plus_jitter(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            delay=15,
+            jitter=30,
+        )
+
+        def loader(oids):
+            return {oid: (b"data-" + oid, p64(50)) for oid in oids}
+
+        with mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep, \
+             mock.patch(
+                 "zodb_pgjsonb.cache_warmer.random.uniform",
+                 return_value=7.0,
+             ):
+            w.warm(loader)
+
+        # First sleep call should be delay + uniform(0, jitter) = 15 + 7 = 22
+        assert mock_sleep.call_args_list[0] == mock.call(22.0)
+
+    def test_warm_no_sleep_when_disabled(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            delay=0,
+            jitter=0,
+        )
+
+        def loader(oids):
+            return {oid: (b"data-" + oid, p64(50)) for oid in oids}
+
+        with mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep:
+            w.warm(loader)
+
+        # When both delay and jitter are zero, no initial sleep call.
+        for c in mock_sleep.call_args_list:
+            assert c.args[0] == 0 or c.args == ()
+
     def test_warm_empty_stats(self):
         from zodb_pgjsonb.cache_warmer import CacheWarmer
         from zodb_pgjsonb.storage import SharedLoadCache

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -557,6 +557,57 @@ class TestCacheWarmerSlot:
 
         assert result is None
 
+    def test_release_slot_unlocks_and_closes(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.cache_warmer import WARMER_LOCK_NS
+        from zodb_pgjsonb.cache_warmer import WARMER_SLOT_BASE
+
+        executed = []
+        closed = []
+
+        class _ReleaseConn:
+            def execute(self, sql, params=None):
+                executed.append((sql, params))
+
+            def close(self):
+                closed.append(True)
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=2,
+        )
+        lock_conn = _ReleaseConn()
+        w._release_slot(lock_conn, slot=2)
+
+        assert len(executed) == 1
+        sql, params = executed[0]
+        assert "pg_advisory_unlock" in sql
+        assert params == (WARMER_LOCK_NS, WARMER_SLOT_BASE + 2)
+        assert closed == [True]
+
+    def test_release_slot_swallows_errors(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        class _BadConn:
+            def execute(self, sql, params=None):
+                raise RuntimeError("connection gone")
+
+            def close(self):
+                raise RuntimeError("close gone too")
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=2,
+        )
+        # Must not raise.
+        w._release_slot(_BadConn(), slot=1)
+
 
 @pytest.mark.db
 class TestCacheWarmerDB:

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -466,6 +466,97 @@ class TestCacheWarmerSlot:
         slot = w._try_acquire_slot_once(lock_conn)
         assert slot is None
 
+    def test_acquire_slot_succeeds_after_retries(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        # First two attempts: all slots taken.  Third attempt: slot 1 free.
+        # With concurrency=2 that's 2 + 2 + 1 = 5 try-lock calls before success.
+        slot_results = [False, False] + [False, False] + [True]
+        lock_conn = self._make_lock_conn(slot_results=slot_results)
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+            wait_max=30,
+        )
+
+        # Patch psycopg.connect to return our pre-built lock_conn, and
+        # patch sleep so the test doesn't actually wait.
+        with mock.patch(
+            "zodb_pgjsonb.cache_warmer.psycopg.connect",
+            return_value=lock_conn,
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.time.sleep"
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.random.uniform",
+            return_value=3.0,
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.time.monotonic",
+            side_effect=[0, 3, 6, 9],
+        ):
+            conn, slot = w._acquire_slot()
+
+        assert conn is lock_conn
+        assert slot == 1
+
+    def test_acquire_slot_times_out(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        # All slots permanently taken.
+        lock_conn = self._make_lock_conn(slot_results=[False] * 100)
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+            wait_max=10,
+        )
+
+        # monotonic side_effect: simulate 0s, 3s, 6s, 9s, 12s — wait_max hit.
+        with mock.patch(
+            "zodb_pgjsonb.cache_warmer.psycopg.connect",
+            return_value=lock_conn,
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.time.sleep"
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.random.uniform",
+            return_value=3.0,
+        ), mock.patch(
+            "zodb_pgjsonb.cache_warmer.time.monotonic",
+            side_effect=[0, 3, 6, 9, 12],
+        ):
+            result = w._acquire_slot()
+
+        assert result is None
+
+    def test_acquire_slot_handles_connect_failure(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=ignored",
+            concurrency=2,
+            wait_max=30,
+        )
+
+        with mock.patch(
+            "zodb_pgjsonb.cache_warmer.psycopg.connect",
+            side_effect=RuntimeError("connect refused"),
+        ):
+            result = w._acquire_slot()
+
+        assert result is None
+
 
 @pytest.mark.db
 class TestCacheWarmerDB:

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -262,6 +262,64 @@ class TestCacheWarmerWarm:
         # First sleep call should be delay + uniform(0, jitter) = 15 + 7 = 22
         assert mock_sleep.call_args_list[0] == mock.call(22.0)
 
+    def test_warm_batches_with_pause(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        # 1100 OIDs at batch_size=500 → 3 batches (500+500+100),
+        # 2 inter-batch sleeps (after batches 1 and 2, not after 3).
+        top = list(range(1, 1101))
+        shared = SharedLoadCache(max_mb=64)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=top),
+            target_count=1100,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            batch_size=500,
+            batch_pause=0.25,
+        )
+
+        call_chunks = []
+
+        def loader(oids):
+            call_chunks.append(len(oids))
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        with mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep:
+            w.warm(loader)
+
+        # Three loader calls, sizes 500, 500, 100.
+        assert call_chunks == [500, 500, 100]
+        # Exactly two batch_pause sleeps of 0.25 (no trailing).
+        pause_calls = [c for c in mock_sleep.call_args_list if c.args == (0.25,)]
+        assert len(pause_calls) == 2
+
+    def test_warm_single_batch_no_pause(self):
+        from ZODB.utils import p64
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        shared = SharedLoadCache(max_mb=4)
+        w = CacheWarmer(
+            conn=_FakeConn(top_oids=[1, 2, 3]),
+            target_count=10,
+            shared_cache=shared,
+            load_current_tid_fn=lambda: 100,
+            batch_size=500,
+            batch_pause=0.5,
+        )
+
+        def loader(oids):
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        with mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep:
+            w.warm(loader)
+
+        # Single batch → zero batch_pause sleeps.
+        pause_calls = [c for c in mock_sleep.call_args_list if c.args == (0.5,)]
+        assert pause_calls == []
+
     def test_warm_no_sleep_when_disabled(self):
         from ZODB.utils import p64
         from zodb_pgjsonb.cache_warmer import CacheWarmer

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -164,6 +164,52 @@ class TestCacheWarmerRecord:
         assert 3 not in w._recorded
 
 
+class TestCacheWarmerNewKwargs:
+    """Confirms the six herd-mitigation kwargs are accepted and stored
+    on the instance with their defaults (off)."""
+
+    def test_defaults_are_off(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+        )
+        assert w._delay == 0
+        assert w._jitter == 0
+        assert w._concurrency == 0
+        assert w._wait_max == 300
+        assert w._batch_size == 500
+        assert w._batch_pause == 0.0
+        assert w._dsn is None
+
+    def test_kwargs_override(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            dsn="dbname=foo",
+            delay=15,
+            jitter=30,
+            concurrency=2,
+            wait_max=120,
+            batch_size=250,
+            batch_pause=0.25,
+        )
+        assert w._delay == 15
+        assert w._jitter == 30
+        assert w._concurrency == 2
+        assert w._wait_max == 120
+        assert w._batch_size == 250
+        assert w._batch_pause == 0.25
+        assert w._dsn == "dbname=foo"
+
+
 class TestCacheWarmerWarm:
     """Test warming phase."""
 

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -381,6 +381,92 @@ class TestCacheWarmerWarm:
         assert len(shared._cache) == 0
 
 
+class TestCacheWarmerSlot:
+    """Unit tests for the B2b advisory-lock slot helpers."""
+
+    def _make_lock_conn(self, slot_results):
+        """Return a mock connection whose execute('SELECT pg_try_advisory_lock(...)')
+        returns ``slot_results[i]`` on the i-th call (one row, one column).
+        """
+        call_count = [0]
+
+        class _LockCursor:
+            def __init__(self):
+                self._row = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def execute(self, sql, params=None):
+                if "pg_try_advisory_lock" in sql:
+                    i = call_count[0]
+                    call_count[0] += 1
+                    self._row = (slot_results[i],) if i < len(slot_results) else (False,)
+                else:
+                    self._row = None
+                return self
+
+            def fetchone(self):
+                return self._row
+
+        class _LockConn:
+            def cursor(self):
+                return _LockCursor()
+
+            def execute(self, *a, **kw):
+                return None
+
+            def close(self):
+                pass
+
+        return _LockConn()
+
+    def test_try_acquire_slot_returns_slot_when_first_free(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=3,
+        )
+        lock_conn = self._make_lock_conn(slot_results=[True])
+        slot = w._try_acquire_slot_once(lock_conn)
+        assert slot == 1
+
+    def test_try_acquire_slot_returns_higher_slot_when_first_taken(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=3,
+        )
+        lock_conn = self._make_lock_conn(slot_results=[False, False, True])
+        slot = w._try_acquire_slot_once(lock_conn)
+        assert slot == 3
+
+    def test_try_acquire_slot_returns_none_when_all_taken(self):
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+
+        w = CacheWarmer(
+            conn=mock.Mock(),
+            target_count=10,
+            shared_cache=_mk_shared_cache(),
+            load_current_tid_fn=lambda: 100,
+            concurrency=3,
+        )
+        lock_conn = self._make_lock_conn(slot_results=[False, False, False])
+        slot = w._try_acquire_slot_once(lock_conn)
+        assert slot is None
+
+
 @pytest.mark.db
 class TestCacheWarmerDB:
     """Integration tests for DB-dependent methods (require PostgreSQL)."""

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -252,11 +252,13 @@ class TestCacheWarmerWarm:
         def loader(oids):
             return {oid: (b"data-" + oid, p64(50)) for oid in oids}
 
-        with mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep, \
-             mock.patch(
-                 "zodb_pgjsonb.cache_warmer.random.uniform",
-                 return_value=7.0,
-             ):
+        with (
+            mock.patch("zodb_pgjsonb.cache_warmer.time.sleep") as mock_sleep,
+            mock.patch(
+                "zodb_pgjsonb.cache_warmer.random.uniform",
+                return_value=7.0,
+            ),
+        ):
             w.warm(loader)
 
         # First sleep call should be delay + uniform(0, jitter) = 15 + 7 = 22
@@ -495,7 +497,9 @@ class TestCacheWarmerSlot:
                 if "pg_try_advisory_lock" in sql:
                     i = call_count[0]
                     call_count[0] += 1
-                    self._row = (slot_results[i],) if i < len(slot_results) else (False,)
+                    self._row = (
+                        (slot_results[i],) if i < len(slot_results) else (False,)
+                    )
                 else:
                     self._row = None
                 return self
@@ -562,7 +566,7 @@ class TestCacheWarmerSlot:
 
         # First two attempts: all slots taken.  Third attempt: slot 1 free.
         # With concurrency=2 that's 2 + 2 + 1 = 5 try-lock calls before success.
-        slot_results = [False, False] + [False, False] + [True]
+        slot_results = [False, False, False, False, True]
         lock_conn = self._make_lock_conn(slot_results=slot_results)
 
         w = CacheWarmer(
@@ -577,17 +581,20 @@ class TestCacheWarmerSlot:
 
         # Patch psycopg.connect to return our pre-built lock_conn, and
         # patch sleep so the test doesn't actually wait.
-        with mock.patch(
-            "zodb_pgjsonb.cache_warmer.psycopg.connect",
-            return_value=lock_conn,
-        ), mock.patch(
-            "zodb_pgjsonb.cache_warmer.time.sleep"
-        ), mock.patch(
-            "zodb_pgjsonb.cache_warmer.random.uniform",
-            return_value=3.0,
-        ), mock.patch(
-            "zodb_pgjsonb.cache_warmer.time.monotonic",
-            side_effect=[0, 3, 6, 9],
+        with (
+            mock.patch(
+                "zodb_pgjsonb.cache_warmer.psycopg.connect",
+                return_value=lock_conn,
+            ),
+            mock.patch("zodb_pgjsonb.cache_warmer.time.sleep"),
+            mock.patch(
+                "zodb_pgjsonb.cache_warmer.random.uniform",
+                return_value=3.0,
+            ),
+            mock.patch(
+                "zodb_pgjsonb.cache_warmer.time.monotonic",
+                side_effect=[0, 3, 6, 9],
+            ),
         ):
             conn, slot = w._acquire_slot()
 
@@ -611,17 +618,20 @@ class TestCacheWarmerSlot:
         )
 
         # monotonic side_effect: simulate 0s, 3s, 6s, 9s, 12s — wait_max hit.
-        with mock.patch(
-            "zodb_pgjsonb.cache_warmer.psycopg.connect",
-            return_value=lock_conn,
-        ), mock.patch(
-            "zodb_pgjsonb.cache_warmer.time.sleep"
-        ), mock.patch(
-            "zodb_pgjsonb.cache_warmer.random.uniform",
-            return_value=3.0,
-        ), mock.patch(
-            "zodb_pgjsonb.cache_warmer.time.monotonic",
-            side_effect=[0, 3, 6, 9, 12],
+        with (
+            mock.patch(
+                "zodb_pgjsonb.cache_warmer.psycopg.connect",
+                return_value=lock_conn,
+            ),
+            mock.patch("zodb_pgjsonb.cache_warmer.time.sleep"),
+            mock.patch(
+                "zodb_pgjsonb.cache_warmer.random.uniform",
+                return_value=3.0,
+            ),
+            mock.patch(
+                "zodb_pgjsonb.cache_warmer.time.monotonic",
+                side_effect=[0, 3, 6, 9, 12],
+            ),
         ):
             result = w._acquire_slot()
 
@@ -839,8 +849,8 @@ class TestCacheWarmerDB:
 
     def test_concurrency_1_serializes_two_warmers(self):
         """Two warmers with concurrency=1 must not warm in parallel."""
-        from ZODB.utils import p64
         from tests.conftest import DSN
+        from ZODB.utils import p64
         from zodb_pgjsonb.cache_warmer import CacheWarmer
         from zodb_pgjsonb.storage import SharedLoadCache
 
@@ -881,8 +891,10 @@ class TestCacheWarmerDB:
 
         t1 = threading.Thread(target=run_warmer)
         t2 = threading.Thread(target=run_warmer)
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         # Two enter/exit pairs, non-overlapping.
         enters = sorted(t for k, t in load_times if k == "enter")
@@ -893,8 +905,8 @@ class TestCacheWarmerDB:
 
     def test_concurrency_2_allows_two_parallel_one_waits(self):
         """Three warmers, concurrency=2 — two warm in parallel, third waits."""
-        from ZODB.utils import p64
         from tests.conftest import DSN
+        from ZODB.utils import p64
         from zodb_pgjsonb.cache_warmer import CacheWarmer
         from zodb_pgjsonb.storage import SharedLoadCache
 
@@ -951,11 +963,9 @@ class TestCacheWarmerDB:
         PG auto-releases the session-level lock so another warmer can
         proceed."""
         from tests.conftest import DSN
-        from zodb_pgjsonb.cache_warmer import (
-            CacheWarmer,
-            WARMER_LOCK_NS,
-            WARMER_SLOT_BASE,
-        )
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.cache_warmer import WARMER_LOCK_NS
+        from zodb_pgjsonb.cache_warmer import WARMER_SLOT_BASE
 
         import psycopg
 
@@ -970,8 +980,12 @@ class TestCacheWarmerDB:
 
         class _StubShared:
             consensus_tid = 1
-            def poll_advance(self, *a, **k): return None
-            def set(self, *a, **k): return True
+
+            def poll_advance(self, *a, **k):
+                return None
+
+            def set(self, *a, **k):
+                return True
 
         # Pod 2: a fresh warmer with concurrency=1 must time out quickly
         # because slot 1 is held.

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -837,6 +837,175 @@ class TestCacheWarmerDB:
         assert len(oids) == 3
         assert set(oids).issubset({100, 200, 300, 400, 500})
 
+    def test_concurrency_1_serializes_two_warmers(self):
+        """Two warmers with concurrency=1 must not warm in parallel."""
+        from ZODB.utils import p64
+        from tests.conftest import DSN
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        import threading
+        import time
+
+        # Seed warm stats so the warmers have something to do.
+        self.conn.execute(
+            "INSERT INTO cache_warm_stats (zoid, score) "
+            "VALUES (1, 5.0), (2, 4.0), (3, 3.0)"
+        )
+
+        shared = SharedLoadCache(max_mb=4)
+        load_times = []
+        load_times_lock = threading.Lock()
+
+        def slow_loader(oids):
+            with load_times_lock:
+                load_times.append(("enter", time.monotonic()))
+            time.sleep(0.5)  # simulate slow load
+            with load_times_lock:
+                load_times.append(("exit", time.monotonic()))
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        def run_warmer():
+            w = CacheWarmer(
+                conn=self.conn,
+                target_count=10,
+                shared_cache=shared,
+                load_current_tid_fn=lambda: 100,
+                dsn=DSN,
+                concurrency=1,
+                wait_max=30,
+                batch_size=500,
+                batch_pause=0,
+            )
+            w.warm(slow_loader)
+
+        t1 = threading.Thread(target=run_warmer)
+        t2 = threading.Thread(target=run_warmer)
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        # Two enter/exit pairs, non-overlapping.
+        enters = sorted(t for k, t in load_times if k == "enter")
+        exits = sorted(t for k, t in load_times if k == "exit")
+        assert len(enters) == 2 and len(exits) == 2
+        # Strict serialization by the advisory lock: first exit before second enter.
+        assert exits[0] <= enters[1] + 0.05  # 50ms slack for thread sched
+
+    def test_concurrency_2_allows_two_parallel_one_waits(self):
+        """Three warmers, concurrency=2 — two warm in parallel, third waits."""
+        from ZODB.utils import p64
+        from tests.conftest import DSN
+        from zodb_pgjsonb.cache_warmer import CacheWarmer
+        from zodb_pgjsonb.storage import SharedLoadCache
+
+        import threading
+        import time
+
+        self.conn.execute(
+            "INSERT INTO cache_warm_stats (zoid, score) "
+            "VALUES (1, 5.0), (2, 4.0), (3, 3.0)"
+        )
+
+        shared = SharedLoadCache(max_mb=4)
+        load_events = []
+        load_events_lock = threading.Lock()
+
+        def slow_loader(oids):
+            with load_events_lock:
+                load_events.append(("enter", time.monotonic()))
+            time.sleep(0.5)
+            with load_events_lock:
+                load_events.append(("exit", time.monotonic()))
+            return {oid: (b"x", p64(50)) for oid in oids}
+
+        def run_warmer():
+            w = CacheWarmer(
+                conn=self.conn,
+                target_count=10,
+                shared_cache=shared,
+                load_current_tid_fn=lambda: 100,
+                dsn=DSN,
+                concurrency=2,
+                wait_max=30,
+                batch_size=500,
+                batch_pause=0,
+            )
+            w.warm(slow_loader)
+
+        threads = [threading.Thread(target=run_warmer) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        enters = sorted(t for k, t in load_events if k == "enter")
+        exits = sorted(t for k, t in load_events if k == "exit")
+        assert len(enters) == 3 and len(exits) == 3
+        # First two enters within a small window (parallel), third
+        # enter must be after at least one exit.
+        assert enters[1] - enters[0] < 0.3
+        assert enters[2] >= exits[0] - 0.05  # 50ms slack
+
+    def test_lock_released_on_connection_close(self):
+        """If the warmer's lock connection closes (e.g. pod crash),
+        PG auto-releases the session-level lock so another warmer can
+        proceed."""
+        from tests.conftest import DSN
+        from zodb_pgjsonb.cache_warmer import (
+            CacheWarmer,
+            WARMER_LOCK_NS,
+            WARMER_SLOT_BASE,
+        )
+
+        import psycopg
+
+        # Pod 1: open a connection, acquire slot 1 manually.
+        conn1 = psycopg.connect(DSN, autocommit=True)
+        with conn1.cursor() as cur:
+            cur.execute(
+                "SELECT pg_try_advisory_lock(%s, %s)",
+                (WARMER_LOCK_NS, WARMER_SLOT_BASE + 1),
+            )
+            assert cur.fetchone()[0] is True
+
+        class _StubShared:
+            consensus_tid = 1
+            def poll_advance(self, *a, **k): return None
+            def set(self, *a, **k): return True
+
+        # Pod 2: a fresh warmer with concurrency=1 must time out quickly
+        # because slot 1 is held.
+        w = CacheWarmer(
+            conn=self.conn,
+            target_count=10,
+            shared_cache=_StubShared(),
+            load_current_tid_fn=lambda: 100,
+            dsn=DSN,
+            concurrency=1,
+            wait_max=3,
+        )
+        assert w._acquire_slot() is None
+
+        # Now close pod 1's connection — auto-releases the lock.
+        conn1.close()
+
+        # Pod 3: a new warmer should now acquire slot 1.
+        w2 = CacheWarmer(
+            conn=self.conn,
+            target_count=10,
+            shared_cache=_StubShared(),
+            load_current_tid_fn=lambda: 100,
+            dsn=DSN,
+            concurrency=1,
+            wait_max=10,
+        )
+        result = w2._acquire_slot()
+        assert result is not None
+        lock_conn, slot = result
+        assert slot == 1
+        # Clean up.
+        w2._release_slot(lock_conn, slot)
+
 
 class TestCacheWarmerFlushEdge:
     """Edge-case tests for _flush() — no DB required."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -286,7 +286,7 @@ class TestCacheWarmHerdConfig:
     pytestmark = pytest.mark.db
 
     def test_warm_knob_defaults(self):
-        """Omitted knobs use the documented production defaults."""
+        """Omitting all six knobs uses the documented production defaults."""
         from tests.conftest import DSN
         from ZODB.config import storageFromString
 
@@ -295,27 +295,19 @@ class TestCacheWarmHerdConfig:
 %import zodb_pgjsonb
 <pgjsonb>
   dsn {DSN}
-  cache-warm-pct 0
 </pgjsonb>
         """
         storage = storageFromString(zconf)
         try:
-            # Warmer disabled (pct=0) but the config defaults still flow
-            # through PGJsonbStorage.__init__.  Verify the stored kwargs.
-            # Direct introspection of the constructor defaults via a
-            # second instantiation is not practical, so verify via the
-            # ZConfig section attributes that the factory reads:
-            import ZODB.config
-
-            schema_text = """\
-<schema>
-    <import package="zodb_pgjsonb" />
-    <section type="pgjsonb" name="*" attribute="storage" />
-</schema>
-            """
-            # Just confirm the storage was constructed; the defaults
-            # are exercised by the override test below.
-            assert storage is not None
+            w = storage._warmer
+            assert w is not None
+            assert w._delay == 15
+            assert w._jitter == 30
+            assert w._concurrency == 2
+            assert w._wait_max == 300
+            assert w._batch_size == 500
+            assert w._batch_pause == 0.5
+            assert w._dsn == DSN
         finally:
             storage.close()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -278,3 +278,76 @@ class TestCacheConfigMigration:
                 assert dep, "expected DeprecationWarning for cache_local_mb"
             finally:
                 storage.close()
+
+
+class TestCacheWarmHerdConfig:
+    """#59: cache-warm-{delay,jitter,concurrency,wait-max,batch-size,batch-pause}."""
+
+    pytestmark = pytest.mark.db
+
+    def test_warm_knob_defaults(self):
+        """Omitted knobs use the documented production defaults."""
+        from tests.conftest import DSN
+        from ZODB.config import storageFromString
+
+        clean_db()
+        zconf = f"""\
+%import zodb_pgjsonb
+<pgjsonb>
+  dsn {DSN}
+  cache-warm-pct 0
+</pgjsonb>
+        """
+        storage = storageFromString(zconf)
+        try:
+            # Warmer disabled (pct=0) but the config defaults still flow
+            # through PGJsonbStorage.__init__.  Verify the stored kwargs.
+            # Direct introspection of the constructor defaults via a
+            # second instantiation is not practical, so verify via the
+            # ZConfig section attributes that the factory reads:
+            import ZODB.config
+
+            schema_text = """\
+<schema>
+    <import package="zodb_pgjsonb" />
+    <section type="pgjsonb" name="*" attribute="storage" />
+</schema>
+            """
+            # Just confirm the storage was constructed; the defaults
+            # are exercised by the override test below.
+            assert storage is not None
+        finally:
+            storage.close()
+
+    def test_warm_knobs_override(self):
+        """All six new knobs thread through ZConfig → PGJsonbStorage → CacheWarmer."""
+        from tests.conftest import DSN
+        from ZODB.config import storageFromString
+
+        clean_db()
+        zconf = f"""\
+%import zodb_pgjsonb
+<pgjsonb>
+  dsn {DSN}
+  cache-warm-pct 5
+  cache-warm-delay 7
+  cache-warm-jitter 11
+  cache-warm-concurrency 3
+  cache-warm-wait-max 60
+  cache-warm-batch-size 250
+  cache-warm-batch-pause 0.25
+</pgjsonb>
+        """
+        storage = storageFromString(zconf)
+        try:
+            w = storage._warmer
+            assert w is not None
+            assert w._delay == 7
+            assert w._jitter == 11
+            assert w._concurrency == 3
+            assert w._wait_max == 60
+            assert w._batch_size == 250
+            assert w._batch_pause == 0.25
+            assert w._dsn == DSN
+        finally:
+            storage.close()


### PR DESCRIPTION
## Summary

Fixes #59 — cluster-wide cache-warmer thundering herd on rolling Kubernetes deploys.

Four composable behaviors added to `CacheWarmer.warm()`:

- **A2** baseline startup delay (`cache-warm-delay`, default 15s) — moves the warmer out of the pod's own cold-start window.
- **A1** uniform-random jitter (`cache-warm-jitter`, default 30s) — spreads arrival times across pods.
- **A3** paced batched warmup (`cache-warm-batch-size` 500, `cache-warm-batch-pause` 0.5s) — lowers per-pod peak qps.
- **B2b** N-slot PG advisory-lock semaphore (`cache-warm-concurrency` 2, `cache-warm-wait-max` 300s) with wait-on-miss + jittered retry — caps cluster-wide concurrent warmers.

Six new ZConfig keys, all defaulting to conservative production values. Reuses the session-level `pg_advisory_lock` pattern from `src/zodb_pgjsonb/startup_locks.py` (introduced in #57), with a dedicated `psycopg.connect` so a pod crash auto-releases the slot.

**Observable behavior change:** warmer queries are now delayed by ~15-45s post-startup, not immediate. Opt-out documented in CHANGES.

**Design:** [docs/superpowers/specs/2026-05-29-cache-warmer-herd-mitigation-design.md](docs/superpowers/specs/2026-05-29-cache-warmer-herd-mitigation-design.md)
**Plan:** [docs/superpowers/plans/2026-05-29-cache-warmer-herd-mitigation.md](docs/superpowers/plans/2026-05-29-cache-warmer-herd-mitigation.md)

## Issue lifecycle

Issue #59 stays **open** after merge — the bigger structural plays (materialized warm-set table, dump-export, replica routing) remain tracked there.

## Test plan

- [ ] `uv run pytest` — full suite green (530 passed locally)
- [ ] `uv run pytest tests/test_cache_warmer.py -v` — 43 warmer tests pass (unit + DB integration)
- [ ] `uv run pytest tests/test_cache_warmer.py::TestCacheWarmerDB -v -k 'concurrency or lock_released'` — three new DB-marked semaphore tests pass against `localhost:5433`
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] Validate on aaf-prod: next rolling deploy should replace the ~90% primary CPU spike with sustained ~30% over ~45s

🤖 Generated with [Claude Code](https://claude.com/claude-code)