### PR TITLE
feat(storage): clear_caches() for out-of-band snapshot restore in tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,15 @@
 
 ### Features
 
+- **`PGJsonbStorage.clear_caches()`** and **`SharedLoadCache.clear()`**:
+  public methods that drop all in-memory caches and reset the consensus
+  TID.  Intended for test harnesses that roll the database *backwards*
+  out of band (e.g. restoring a snapshot between tests): the monotonic
+  shared cache cannot otherwise recover and keeps serving object state
+  at TIDs newer than the rolled-back database, causing spurious
+  ``ConflictError`` on the next commit.  Not needed in production, where
+  TIDs never decrease.
+
 - **Cache warmer herd mitigation** (#59).  Rolling Kubernetes deploys
   used to multiply DB primary CPU by the replica count for the warmer
   startup window, because every pod independently fired its full set

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -328,6 +328,21 @@ class SharedLoadCache:
                         self._current_bytes -= len(entry[0])
                 self._consensus_tid = new_tid
 
+    def clear(self):
+        """Drop all entries and reset the consensus TID.
+
+        The consensus model is strictly monotonic and cannot recover when
+        the backing database is rolled *backwards* out of band — e.g. a
+        test harness restoring a snapshot, which re-inserts rows at their
+        older TIDs.  Clearing resets consensus to ``None`` so the next
+        ``poll_advance`` re-establishes it from the (lower) current TID.
+        In production TIDs never decrease, so this is not needed there.
+        """
+        with self._lock:
+            self._cache.clear()
+            self._consensus_tid = None
+            self._current_bytes = 0
+
 
 class PGTransactionRecord(TransactionRecord):
     """Transaction record yielded by PGJsonbStorage.iterator()."""
@@ -811,6 +826,21 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
 
     def sync(self, force=True):
         """Sync snapshot (no-op for main storage)."""
+
+    def clear_caches(self):
+        """Drop all in-memory caches (shared L2, main L1, serial cache).
+
+        For test harnesses that roll the database *backwards* out of band
+        (e.g. snapshot restore between tests): the process-wide
+        ``SharedLoadCache`` outlives a single ``ZODB.DB`` connection pool,
+        so clearing the ZODB caches alone leaves it serving object state at
+        TIDs newer than the rolled-back database, causing spurious
+        ``ConflictError`` on the next commit.  In production TIDs never
+        decrease, so this is not part of the normal code path.
+        """
+        self._shared_cache.clear()
+        self._load_cache.clear()
+        self._serial_cache.clear()
 
     # ── TID generation (thread-safe, shared across instances) ────────
 

--- a/tests/test_shared_load_cache.py
+++ b/tests/test_shared_load_cache.py
@@ -172,6 +172,17 @@ class TestPGJsonbStorageIntegration:
         finally:
             s.close()
 
+    def test_clear_caches_resets_shared_cache(self, storage):
+        """storage.clear_caches() empties the process-wide shared cache."""
+        sc = storage._shared_cache
+        sc.poll_advance(new_tid=100, changed_zoids=[])
+        sc.set(zoid=1, data=b"x" * 50, tid_bytes=p64(100), polled_tid=100)
+
+        storage.clear_caches()
+
+        assert sc.consensus_tid is None
+        assert len(sc._cache) == 0
+
     def test_cache_per_connection_mb_controls_l1(self):
         """cache_per_connection_mb controls per-instance L1 cache size."""
         from tests.conftest import clean_db
@@ -231,3 +242,39 @@ class TestSharedLoadCacheAPIExtensions:
         cache.set(zoid=1, data=b"new", tid_bytes=p64(200), polled_tid=200)
         accepted = cache.set(zoid=1, data=b"older", tid_bytes=p64(100), polled_tid=200)
         assert accepted is False
+
+
+class TestClear:
+    """clear() drops all entries and resets the consensus TID.
+
+    Needed when the backing database is rolled *backwards* out of band
+    (e.g. a test harness restoring a snapshot), which the monotonic
+    consensus model otherwise cannot recover from.
+    """
+
+    def test_clear_empties_cache_and_resets_consensus(self):
+        cache = SharedLoadCache(max_mb=4)
+        cache.poll_advance(new_tid=100, changed_zoids=[])
+        cache.set(zoid=1, data=b"x" * 50, tid_bytes=p64(100), polled_tid=100)
+
+        cache.clear()
+
+        assert cache._consensus_tid is None
+        assert len(cache._cache) == 0
+        assert cache._current_bytes == 0
+
+    def test_clear_allows_backwards_tid_afterwards(self):
+        """After clear(), a lower TID is accepted again (DB rolled back)."""
+        cache = SharedLoadCache(max_mb=4)
+        cache.poll_advance(new_tid=200, changed_zoids=[])
+        cache.set(zoid=1, data=b"at200", tid_bytes=p64(200), polled_tid=200)
+
+        cache.clear()
+
+        # DB is now back at an older TID; consensus must accept it.
+        cache.poll_advance(new_tid=100, changed_zoids=[])
+        assert cache.consensus_tid == 100
+        # The stale entry is gone, and a fresh write at the lower TID sticks.
+        assert cache.get(zoid=1, polled_tid=100) is None
+        cache.set(zoid=1, data=b"at100", tid_bytes=p64(100), polled_tid=100)
+        assert cache.get(zoid=1, polled_tid=100) == (b"at100", p64(100))


### PR DESCRIPTION
## Problem

The process-wide `SharedLoadCache` (L2, added in 1.12.0 / #63) outlives a `ZODB.DB` connection pool and uses a **strictly monotonic** consensus TID. Test harnesses that roll the database *backwards* out of band — e.g. restoring a snapshot between tests (`PGTestDB.restore()` does `DELETE` + `COPY` of baseline rows at their original, lower TIDs) — leave the shared cache serving object state at TIDs **newer** than the rolled-back DB. The next commit then conflict-checks the in-memory `_serial` (newer) against the DB row (older) and raises a spurious, unresolvable `ConflictError`.

This surfaced downstream in `plone.pgcatalog`: two `clearFindAndRebuild` integration tests fail with `ConflictError` on `Products.ZCTextIndex...PLexicon` whenever a rebuild test runs after another rebuild test. Green before 1.12.0 (no shared cache), red after.

## Fix

Add two public methods:

- `SharedLoadCache.clear()` — drop all entries and reset `_consensus_tid` to `None`, so the next `poll_advance` re-establishes consensus from the (lower) current TID.
- `PGJsonbStorage.clear_caches()` — reset the shared L2 cache, the main L1 load cache, and the serial cache.

In production TIDs never decrease (pack never lowers a live object's TID), so this is **not** part of the normal code path — it is a hook for test harnesses doing out-of-band rollbacks.

## Tests

TDD: `tests/test_shared_load_cache.py` gains `TestClear` (incl. a backwards-TID regression: after `clear()`, a lower TID is accepted again) and a storage-level `clear_caches()` test.

- New tests: 3 passed (RED→GREEN verified).
- Full suite: **533 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)