### PR TITLE
fix: bound per-instance blob materialization dir (#71)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## unreleased
+
+### Bugfixes
+
+- **Bound the per-instance blob materialization dir** (#71).  Each
+  `PGJsonbStorageInstance` used to materialize every blob read via
+  `loadBlob()` into its own `tempfile.mkdtemp(prefix="zodb-pgjsonb-blobs-")`
+  directory with no size limit, cleaned only on a clean `close()`.  On
+  long-running pods this filled local/ephemeral disk (11–14 GB per pod
+  observed) and triggered node `DiskPressure`; instances killed
+  abnormally leaked their dir entirely.  For S3-tiered blobs it was
+  doubly wasteful — every blob was stored both in the unbounded dir and
+  in the bounded `S3BlobCache`.
+
+  Read blobs are now materialized through a single, process-wide
+  **bounded** cache (LRU by access time) for both PG-bytea and S3 blobs:
+
+  - When S3 is configured the existing `S3BlobCache` is reused as the
+    materialization target (no more duplicate copy in the temp dir).
+  - Without S3 a new `LocalBlobCache` (in `zodb_pgjsonb.blob_cache`)
+    provides the same bound for PG-bytea blobs.
+
+  Both are sized by the existing `blob-cache-size` ZConfig key (default
+  1 GB), which now applies with or without S3.  The per-instance temp
+  dir is retained only for transient write-staging.  On startup the
+  storage also sweeps orphaned `zodb-pgjsonb-blobs-*` dirs left by
+  pre-1.14 workers (conservatively: never its own, only dirs older than
+  an hour).
+
 ## 1.13.0
 
 ### Features

--- a/src/zodb_pgjsonb/blob_cache.py
+++ b/src/zodb_pgjsonb/blob_cache.py
@@ -1,0 +1,148 @@
+"""Bounded local filesystem cache for materialized blob files.
+
+``loadBlob`` must return a local file path for every blob it is asked
+for.  Without a bound, those materialized files accumulate for the whole
+lifetime of a worker process and fill local/ephemeral disk (#71).
+
+``LocalBlobCache`` is a size-bounded LRU (by access time) cache used as
+the single materialization target for *both* PG-bytea blobs and blobs
+downloaded from S3.  It mirrors the get/put interface of
+``zodb_s3blobs.cache.S3BlobCache`` (which is used directly when S3 is
+configured) so ``loadBlob`` can treat either interchangeably.
+
+Eviction-while-open is safe: ZODB opens the returned path immediately and
+on POSIX an open file descriptor keeps the inode alive after the path is
+unlinked, so an in-flight read survives a concurrent eviction.  The same
+guarantee already backs the S3 cache.
+"""
+
+from ZODB.utils import oid_repr
+
+import contextlib
+import logging
+import os
+import shutil
+import threading
+
+
+logger = logging.getLogger(__name__)
+
+
+def _hex(data):
+    """Convert oid/tid bytes to a compact hex string (no 0x prefix)."""
+    return oid_repr(data).removeprefix("0x").lstrip("0") or "0"
+
+
+class LocalBlobCache:
+    """Local filesystem LRU cache for materialized blobs.
+
+    Files are stored as ``{cache_dir}/{oid_hex}/{tid_hex}.blob``.  A
+    background thread removes the oldest files (by atime) once the total
+    size exceeds ``max_size``.
+    """
+
+    def __init__(self, cache_dir, max_size=1024 * 1024 * 1024):
+        self.cache_dir = cache_dir
+        self.max_size = max_size
+        self._target_size = int(max_size * 0.9)
+        self._check_threshold = max(int(max_size * 0.1), 1)
+        self._bytes_loaded = 0
+        self._lock = threading.Lock()
+        self._checker_thread = None
+        os.makedirs(cache_dir, exist_ok=True, mode=0o700)
+
+    def _blob_path(self, oid, tid):
+        return os.path.join(self.cache_dir, _hex(oid), f"{_hex(tid)}.blob")
+
+    def get(self, oid, tid):
+        """Return the cached path for (oid, tid), or None on miss.
+
+        Touches atime so the LRU keeps recently used blobs.
+        """
+        path = self._blob_path(oid, tid)
+        try:
+            os.utime(path)  # touch atime; also verifies the file exists
+            return path
+        except FileNotFoundError:
+            return None
+
+    def put(self, oid, tid, source_path):
+        """Copy ``source_path`` into the cache and return its cached path."""
+        path = self._blob_path(oid, tid)
+        os.makedirs(os.path.dirname(path), exist_ok=True, mode=0o700)
+        shutil.copy2(source_path, path)
+        self.notify_loaded(os.path.getsize(path))
+        return path
+
+    def notify_loaded(self, byte_count):
+        with self._lock:
+            self._bytes_loaded += byte_count
+            if self._bytes_loaded >= self._check_threshold:
+                self._bytes_loaded = 0
+                self._start_cleanup()
+
+    def _start_cleanup(self):
+        """Start the background cleanup thread (call with ``_lock`` held)."""
+        if self._checker_thread is not None and self._checker_thread.is_alive():
+            return
+        t = threading.Thread(target=self._cleanup, daemon=True)
+        self._checker_thread = t
+        t.start()
+
+    def _cleanup(self):
+        """Remove oldest files (by atime) until under the target size."""
+        try:
+            files = []
+            for dirpath, _dirnames, filenames in os.walk(self.cache_dir):
+                for fn in filenames:
+                    if fn.endswith(".blob"):
+                        fp = os.path.join(dirpath, fn)
+                        try:
+                            st = os.stat(fp)
+                            files.append((st.st_atime, st.st_size, fp))
+                        except OSError:
+                            pass
+
+            total_size = sum(size for _, size, _ in files)
+            if total_size <= self.max_size:
+                return
+
+            files.sort(key=lambda x: x[0])  # oldest atime first
+            for _atime, size, fp in files:
+                if total_size <= self._target_size:
+                    break
+                try:
+                    os.remove(fp)
+                    total_size -= size
+                    parent = os.path.dirname(fp)
+                    if parent != self.cache_dir:
+                        with contextlib.suppress(OSError):
+                            os.rmdir(parent)
+                except OSError:
+                    pass
+        except Exception:
+            logger.exception("Error during blob cache cleanup")
+
+    def close(self):
+        """Wait for any running cleanup thread to finish."""
+        with self._lock:
+            t = self._checker_thread
+        if t is not None:
+            t.join(timeout=5)
+
+    def wait_for_cleanup(self):
+        """Wait for any running cleanup thread to finish (for testing)."""
+        with self._lock:
+            t = self._checker_thread
+        if t is not None:
+            t.join(timeout=10)
+
+    def current_size(self):
+        """Total size of cached files (for testing)."""
+        total = 0
+        for dirpath, _dirnames, filenames in os.walk(self.cache_dir):
+            for fn in filenames:
+                if fn.endswith(".blob"):
+                    with contextlib.suppress(OSError):
+                        total += os.path.getsize(os.path.join(dirpath, fn))
+        return total

--- a/src/zodb_pgjsonb/component.xml
+++ b/src/zodb_pgjsonb/component.xml
@@ -203,7 +203,10 @@
 
     <key name="blob-cache-size" datatype="byte-size" default="1GB">
       <description>
-        Maximum size of local blob cache. Default: 1GB.
+        Maximum size of the local blob cache used to materialize read
+        blobs. Applies with or without S3: it bounds both the S3 download
+        cache and the local cache for PG-bytea blobs (oldest evicted by
+        access time) so local disk usage stays capped. Default: 1GB.
       </description>
     </key>
 

--- a/src/zodb_pgjsonb/config.py
+++ b/src/zodb_pgjsonb/config.py
@@ -77,6 +77,9 @@ class PGJsonbStorageFactory(BaseConfig):
             "pool_timeout": config.pool_timeout,
             "s3_client": s3_client,
             "blob_cache": blob_cache,
+            # Also sizes the local materialization cache used when S3 is
+            # not configured (PG-bytea blobs) — see PGJsonbStorage (#71).
+            "blob_cache_size": getattr(config, "blob_cache_size", 1024 * 1024 * 1024),
             "blob_threshold": getattr(config, "blob_threshold", 100 * 1024),
             "cache_warm_pct": getattr(config, "cache_warm_pct", 10),
             "cache_warm_decay": getattr(config, "cache_warm_decay", 0.8),

--- a/src/zodb_pgjsonb/instance.py
+++ b/src/zodb_pgjsonb/instance.py
@@ -13,9 +13,9 @@ from .conflict import _batch_check_read_conflicts
 from .conflict import _batch_resolve_conflicts
 from .serialization import _unsanitize_from_pg
 from .storage import _do_loadSerial
-from .storage import _load_blob_from_s3
 from .storage import _loadBefore_hf
 from .storage import _loadBefore_hp
+from .storage import _materialize_blob
 from .storage import _NoopSerialCache
 from .storage import _read_max_tid
 from .storage import LoadCache
@@ -543,46 +543,24 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
     def loadBlob(self, oid, serial):
         """Return path to a file containing the blob data.
 
-        Uses deterministic filenames so repeated calls for the same
-        (oid, serial) return the same path — required by ZODB.blob.Blob.
+        Read blobs are materialized through the process-wide bounded
+        ``_blob_cache`` (see ``_materialize_blob``) rather than into this
+        instance's temp dir, so local disk usage stays capped for the
+        instance's whole lifetime (#71).
         """
         zoid = u64(oid)
-        tid_int = u64(serial)
         # Check pending blobs first (staged in current txn, not yet in DB)
         pending = self._blob_tmp.get(zoid)
         if pending is not None and os.path.exists(pending):
             return pending
-        path = os.path.join(self._blob_temp_dir, f"{zoid:016x}-{tid_int:016x}.blob")
-        if os.path.exists(path):
-            return path
-        # Check S3 blob cache before hitting the database
-        if self._blob_cache is not None:
-            cached = self._blob_cache.get(oid, serial)
-            if cached:
-                return cached
-        with self._conn.cursor() as cur:
-            cur.execute(
-                "SELECT data, s3_key FROM blob_state WHERE zoid = %s AND tid = %s",
-                (zoid, tid_int),
-            )
-            row = cur.fetchone()
-        if row is None:
-            raise POSKeyError(oid)
-        if row["s3_key"]:
-            return _load_blob_from_s3(
-                self._s3_client,
-                self._blob_cache,
-                row["s3_key"],
-                oid,
-                serial,
-                path,
-            )
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        try:
-            os.write(fd, row["data"])
-        finally:
-            os.close(fd)
-        return path
+        return _materialize_blob(
+            self._conn,
+            self._blob_cache,
+            self._s3_client,
+            self._blob_temp_dir,
+            oid,
+            serial,
+        )
 
     def openCommittedBlobFile(self, oid, serial, blob=None):
         """Open committed blob file for reading."""

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -406,6 +406,7 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
         pool_timeout=30.0,
         s3_client=None,
         blob_cache=None,
+        blob_cache_size=1024 * 1024 * 1024,
         blob_threshold=102_400,
         cache_warm_pct=10,
         cache_warm_decay=0.8,
@@ -442,7 +443,12 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
 
         # S3 tiered blob storage (optional)
         self._s3_client = s3_client  # None = PG-only mode
-        self._blob_cache = blob_cache  # S3BlobCache for local caching
+        # Bounded local cache used to materialize read blobs (#71).  When
+        # S3 is configured the caller passes an S3BlobCache; otherwise we
+        # create an equivalent local cache below so loadBlob always has a
+        # bounded target instead of an unbounded per-instance temp dir.
+        self._blob_cache = blob_cache
+        self._blob_cache_size = blob_cache_size
         self._blob_threshold = blob_threshold  # bytes; blobs >= this go to S3
 
         # State processors (plugins that extract extra column data during writes)
@@ -461,11 +467,32 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
         self._tmp = []
         self._blob_tmp = {}  # pending blob stores: {oid_int: blob_path}
 
-        # Blob temp directory
+        # Blob temp directory — used only for transient write-staging
+        # (storeBlob/restoreBlob and ZODB's uncommitted blobs).  Read
+        # materialization no longer lands here (#71).
         self._blob_temp_dir = blob_temp_dir or tempfile.mkdtemp(
             prefix="zodb-pgjsonb-blobs-"
         )
         os.makedirs(self._blob_temp_dir, exist_ok=True)
+
+        # Remove orphaned per-instance dirs left by abnormally terminated
+        # workers running zodb-pgjsonb <= 1.13 (which materialized read
+        # blobs into per-instance "zodb-pgjsonb-blobs-*" dirs and only
+        # cleaned them on a clean close()).  Conservative: skip our own
+        # dir and anything younger than an hour, so a concurrently
+        # starting peer is never disturbed.
+        self._sweep_orphan_blob_dirs()
+
+        # Ensure a bounded materialization cache always exists.  With S3
+        # the caller supplies an S3BlobCache; without it, fall back to a
+        # local bounded cache so PG-bytea read blobs are capped too (#71).
+        if self._blob_cache is None:
+            from .blob_cache import LocalBlobCache
+
+            self._blob_cache = LocalBlobCache(
+                cache_dir=os.path.join(self._blob_temp_dir, "_materialized"),
+                max_size=blob_cache_size,
+            )
 
         # Per-instance L1 load cache (small, fast path, no lock).
         # Size from cache_per_connection_mb.  See instance.py.
@@ -1414,46 +1441,23 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
     def loadBlob(self, oid, serial):
         """Return path to a file containing the blob data.
 
-        Uses deterministic filenames so repeated calls for the same
-        (oid, serial) return the same path — required by ZODB.blob.Blob.
+        Read blobs are materialized through the bounded ``_blob_cache``
+        (see ``_materialize_blob``) so local disk usage stays capped
+        instead of growing for the storage's lifetime (#71).
         """
         zoid = u64(oid)
-        tid_int = u64(serial)
         # Check pending blobs first (staged in current txn, not yet in DB)
         pending = self._blob_tmp.get(zoid)
         if pending is not None and os.path.exists(pending):
             return pending
-        path = os.path.join(self._blob_temp_dir, f"{zoid:016x}-{tid_int:016x}.blob")
-        if os.path.exists(path):
-            return path
-        # Check S3 blob cache before hitting the database
-        if self._blob_cache is not None:
-            cached = self._blob_cache.get(oid, serial)
-            if cached:
-                return cached
-        with self._conn.cursor() as cur:
-            cur.execute(
-                "SELECT data, s3_key FROM blob_state WHERE zoid = %s AND tid = %s",
-                (zoid, tid_int),
-            )
-            row = cur.fetchone()
-        if row is None:
-            raise POSKeyError(oid)
-        if row["s3_key"]:
-            return _load_blob_from_s3(
-                self._s3_client,
-                self._blob_cache,
-                row["s3_key"],
-                oid,
-                serial,
-                path,
-            )
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        try:
-            os.write(fd, row["data"])
-        finally:
-            os.close(fd)
-        return path
+        return _materialize_blob(
+            self._conn,
+            self._blob_cache,
+            self._s3_client,
+            self._blob_temp_dir,
+            oid,
+            serial,
+        )
 
     def openCommittedBlobFile(self, oid, serial, blob=None):
         """Open committed blob file for reading."""
@@ -1468,6 +1472,39 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
         """Return directory for uncommitted blob data."""
         return self._blob_temp_dir
 
+    def _sweep_orphan_blob_dirs(self):
+        """Delete orphaned "zodb-pgjsonb-blobs-*" dirs from dead workers.
+
+        Pre-1.14 instances materialized read blobs into per-instance
+        mkdtemp dirs that were only removed on a clean close(); abnormal
+        termination (pod eviction/crash) leaked them entirely (#71).
+        Sweep them on startup, but conservatively: never touch our own
+        dir, and only remove dirs older than an hour so a peer process
+        starting at the same time is left alone.
+        """
+        import time
+
+        root = os.path.dirname(os.path.abspath(self._blob_temp_dir))
+        own = os.path.abspath(self._blob_temp_dir)
+        cutoff = time.time() - 3600
+        try:
+            entries = os.listdir(root)
+        except OSError:
+            return
+        for name in entries:
+            if not name.startswith("zodb-pgjsonb-blobs-"):
+                continue
+            path = os.path.join(root, name)
+            if os.path.abspath(path) == own or not os.path.isdir(path):
+                continue
+            try:
+                if os.stat(path).st_mtime >= cutoff:
+                    continue
+            except OSError:
+                continue
+            logger.info("Removing orphaned blob temp dir: %s", path)
+            shutil.rmtree(path, ignore_errors=True)
+
     # ── IStorage: close ──────────────────────────────────────────────
 
     def close(self):
@@ -1476,6 +1513,8 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
             self._conn.close()
         if hasattr(self, "_instance_pool"):
             self._instance_pool.close()
+        if self._blob_cache is not None and hasattr(self._blob_cache, "close"):
+            self._blob_cache.close()
         if os.path.exists(self._blob_temp_dir):
             shutil.rmtree(self._blob_temp_dir, ignore_errors=True)
 
@@ -1617,24 +1656,54 @@ def _mask_dsn(dsn):
     return _DSN_PASSWORD_RE.sub(r"\1***", dsn)
 
 
-def _load_blob_from_s3(s3_client, blob_cache, s3_key, oid, serial, path):
-    """Download a blob from S3 and optionally cache it locally.
+def _materialize_blob(conn, blob_cache, s3_client, staging_dir, oid, serial):
+    """Return a local path to the blob for (oid, serial).
+
+    Reads are materialized through the *bounded* ``blob_cache`` for both
+    PG-bytea and S3-tiered blobs, so local disk usage is capped by the
+    cache's ``max_size`` instead of growing for the worker's lifetime
+    (#71).  Bytes are first written to a short-lived staging file in
+    ``staging_dir`` and then handed to ``blob_cache.put``; the staging
+    file is removed immediately afterwards.
 
     Args:
-        s3_client: S3Client instance
-        blob_cache: S3BlobCache instance or None
-        s3_key: S3 key string
+        conn: psycopg connection used for the blob_state lookup
+        blob_cache: bounded local cache (LocalBlobCache or S3BlobCache)
+        s3_client: S3Client instance, or None for PG-only mode
+        staging_dir: directory for the transient download/write file
         oid: OID bytes
         serial: TID bytes
-        path: local file path to write to
 
     Returns:
-        Path to the local blob file.
+        Path to the cached local blob file.
     """
-    s3_client.download_file(s3_key, path)
-    if blob_cache is not None:
-        blob_cache.put(oid, serial, path)
-    return path
+    cached = blob_cache.get(oid, serial)
+    if cached:
+        return cached
+
+    zoid = u64(oid)
+    tid_int = u64(serial)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT data, s3_key FROM blob_state WHERE zoid = %s AND tid = %s",
+            (zoid, tid_int),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise POSKeyError(oid)
+
+    fd, staging = tempfile.mkstemp(dir=staging_dir, suffix=".tmp")
+    os.close(fd)
+    try:
+        if row["s3_key"]:
+            s3_client.download_file(row["s3_key"], staging)
+        else:
+            with open(staging, "wb") as f:
+                f.write(row["data"])
+        return blob_cache.put(oid, serial, staging)
+    finally:
+        if os.path.exists(staging):
+            os.unlink(staging)
 
 
 def _do_loadSerial(conn, serial_cache, history_preserving, oid, serial):

--- a/tests/test_blobs.py
+++ b/tests/test_blobs.py
@@ -238,6 +238,76 @@ class TestBlobStoreAndLoad:
         inst.release()
 
 
+class TestBlobMaterializationBounded:
+    """Regression for #71 — loadBlob must materialize read blobs through a
+    bounded cache, never accumulate them in the per-instance temp dir
+    (which filled local disk to 11-14 GB per pod in production).
+    """
+
+    def _store_blob(self, inst, payload):
+        import zodb_json_codec
+
+        record = {
+            "@cls": ["persistent.mapping", "PersistentMapping"],
+            "@s": {"data": {}},
+        }
+        data = zodb_json_codec.encode_zodb_record(record)
+        fd, blob_path = tempfile.mkstemp()
+        os.write(fd, payload)
+        os.close(fd)
+        t = txn.Transaction()
+        inst.tpc_begin(t)
+        oid = inst.new_oid()
+        inst.storeBlob(oid, z64, data, blob_path, "", t)
+        inst.tpc_vote(t)
+        tid = inst.tpc_finish(t)
+        return oid, tid
+
+    def test_loadblob_does_not_accumulate_in_instance_dir(self, storage):
+        """Loading many distinct blobs must not pile up *.blob files in the
+        per-instance temp dir — the unbounded growth that triggered #71."""
+        inst = storage.new_instance()
+        inst.poll_invalidations()
+
+        oids_tids = [self._store_blob(inst, b"B" * 4096) for _ in range(20)]
+
+        # Force materialization of every blob (read path).
+        for oid, tid in oids_tids:
+            path = inst.loadBlob(oid, tid)
+            assert os.path.isfile(path)
+
+        leftover = [f for f in os.listdir(inst._blob_temp_dir) if f.endswith(".blob")]
+        assert leftover == [], (
+            f"loadBlob leaked {len(leftover)} materialized blobs into the "
+            f"per-instance temp dir {inst._blob_temp_dir}: {leftover[:5]}"
+        )
+        inst.release()
+
+    def test_materialization_cache_is_bounded_without_s3(self):
+        """Without S3, the local materialization cache evicts so total disk
+        stays under blob_cache_size even after many distinct reads (#71)."""
+        clean_db()
+        max_size = 64 * 1024
+        s = PGJsonbStorage(DSN, blob_cache_size=max_size)
+        try:
+            inst = s.new_instance()
+            inst.poll_invalidations()
+
+            oids_tids = [self._store_blob(inst, b"X" * 8192) for _ in range(40)]
+            for oid, tid in oids_tids:
+                assert os.path.isfile(inst.loadBlob(oid, tid))
+
+            s._blob_cache.wait_for_cleanup()
+            size = s._blob_cache.current_size()
+            assert size <= max_size, (
+                f"materialization cache grew to {size} bytes, over the "
+                f"{max_size}-byte bound"
+            )
+            inst.release()
+        finally:
+            s.close()
+
+
 class TestBlobsWithZODB:
     """Test blob objects through ZODB.DB."""
 
@@ -520,8 +590,12 @@ class TestS3BlobTiering:
 
     def test_no_s3_config_all_pg(self, storage):
         """Without S3 config, all blobs go to PG (backward compatible)."""
+        from zodb_pgjsonb.blob_cache import LocalBlobCache
+
         assert storage._s3_client is None
-        assert storage._blob_cache is None
+        # No S3, but a bounded local materialization cache still exists so
+        # read blobs don't accumulate unbounded on local disk (#71).
+        assert isinstance(storage._blob_cache, LocalBlobCache)
 
     def test_blob_threshold_zero_all_s3(self, tmp_path):
         """With threshold=0, all blobs go to S3."""


### PR DESCRIPTION
Fixes #71.

## Problem

`PGJsonbStorageInstance.loadBlob()` materialized **every** read blob into a per-instance `tempfile.mkdtemp(prefix="zodb-pgjsonb-blobs-")` directory with **no size limit**, cleaned only on a clean `close()`. On long-running pods this filled local/ephemeral disk (11–14 GB per pod observed) → node `DiskPressure` → pod evictions; instances killed abnormally leaked their dir entirely.

For S3-tiered blobs it was doubly wasteful: each blob was stored in **both** the unbounded dir **and** the bounded `S3BlobCache`. (The write-staging path was already cleaned at vote, so reads were the sole leak.)

## Fix

Read blobs are now materialized through a single, process-wide **bounded** cache (LRU by access time) for both PG-bytea and S3 blobs:

- When S3 is configured, the existing `S3BlobCache` is reused as the materialization target — no more duplicate copy in the temp dir.
- Without S3, a new `LocalBlobCache` (`zodb_pgjsonb.blob_cache`) provides the same bound for PG-bytea blobs.
- Both are sized by the existing `blob-cache-size` ZConfig key (default 1 GB), which now applies **with or without** S3.
- The per-instance temp dir is retained only for transient write-staging.
- On startup the storage sweeps orphaned `zodb-pgjsonb-blobs-*` dirs left by pre-1.14 workers — conservatively: never its own, only dirs older than an hour (safe across peer processes/pods).

Read materialization for both `loadBlob` implementations (main storage + instance) now goes through a shared `_materialize_blob()` helper. Eviction-while-open is safe (an open fd keeps the inode alive on POSIX) — the same guarantee that already backed the S3 cache.

## Tests

- New regression test: loading 20 distinct blobs leaves **0** `.blob` files in the per-instance temp dir (failed with 20 leaked files before the fix).
- New bound test: the local materialization cache evicts to stay under `blob_cache_size`.
- Blob + config + mvcc + stress + migration suites pass (93). Full suite: 530 passed; the 5 `PGJsonbRecoveryHP` failures are pre-existing (unrelated HP recovery TID collision, reproduces on clean `main`).
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)