### PR TITLE
test: derive recovery destination DSN robustly from any source DSN

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## unreleased
+
+### Tests
+
+- **Recovery conformance: robust destination DSN derivation.**
+  `PGJsonbRecoveryHP` built the destination DSN via
+  `DSN.replace("dbname=zodb_test", ...)`, which silently no-ops for any
+  DSN whose dbname is not literally `zodb_test` (e.g. a `ZODB_TEST_DSN`
+  with `dbname=zodb`), leaving source and destination on the same
+  database and producing confusing `transaction_log_pkey` duplicate-key
+  failures.  The destination dbname is now derived from the source DSN
+  (`<src>_dst`) via regex and asserted distinct, so the tests work with
+  any libpq key=value DSN and a broken derivation fails loudly.
+
 ## 1.13.0
 
 ### Features

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -38,6 +38,7 @@ from zodb_pgjsonb.storage import PGJsonbStorage
 
 import psycopg
 import pytest
+import re
 import threading
 import time
 import transaction
@@ -348,30 +349,45 @@ class PGJsonbRecoveryHP(StorageTestBase, RecoveryStorage):
     """ZODB conformance — recovery (history-preserving mode).
 
     RecoveryStorage tests copyTransactionsFrom, restore, and pack on
-    a destination storage.  Uses a separate database (zodb_test_dst)
-    for the destination storage.
+    a destination storage, which must live in a *separate* database so
+    its TIDs/OIDs don't collide with the source.  The destination DB
+    name is derived from the source DSN's dbname (``<src>_dst``) so the
+    isolation holds for any configured DSN, not just ``dbname=zodb_test``.
     """
 
-    _DST_DB = "zodb_test_dst"
+    @staticmethod
+    def _dbname(dsn):
+        """Extract the dbname from a libpq key=value DSN."""
+        match = re.search(r"\bdbname=(\S+)", dsn)
+        if not match:
+            raise ValueError(f"Cannot find dbname in DSN: {dsn!r}")
+        return match.group(1)
 
     def setUp(self):
         super().setUp()
-        # Create destination database
+        src_db = self._dbname(DSN)
+        self._dst_db = f"{src_db}_dst"
+        dst_dsn = re.sub(r"\bdbname=\S+", f"dbname={self._dst_db}", DSN, count=1)
+        # Guard against a DSN form that silently leaves source == dest,
+        # which would surface as confusing duplicate-key errors mid-test.
+        assert self._dst_db != src_db
+        assert dst_dsn != DSN, f"destination DSN not distinct from source: {DSN!r}"
+
+        # Create a fresh destination database.
         admin_conn = psycopg.connect(DSN)
         admin_conn.autocommit = True
         admin_conn.execute(
             "SELECT pg_terminate_backend(pid) "
             "FROM pg_stat_activity "
             "WHERE datname = %s AND pid != pg_backend_pid()",
-            (self._DST_DB,),
+            (self._dst_db,),
         )
-        admin_conn.execute(f"DROP DATABASE IF EXISTS {self._DST_DB}")
-        admin_conn.execute(f"CREATE DATABASE {self._DST_DB}")
+        admin_conn.execute(f"DROP DATABASE IF EXISTS {self._dst_db}")
+        admin_conn.execute(f"CREATE DATABASE {self._dst_db}")
         admin_conn.close()
 
         clean_db()
         self._storage = PGJsonbStorage(DSN, history_preserving=True)
-        dst_dsn = DSN.replace("dbname=zodb_test", f"dbname={self._DST_DB}")
         self._dst = PGJsonbStorage(dst_dsn, history_preserving=True)
 
     def tearDown(self):
@@ -385,9 +401,9 @@ class PGJsonbRecoveryHP(StorageTestBase, RecoveryStorage):
             "SELECT pg_terminate_backend(pid) "
             "FROM pg_stat_activity "
             "WHERE datname = %s AND pid != pg_backend_pid()",
-            (self._DST_DB,),
+            (self._dst_db,),
         )
-        admin_conn.execute(f"DROP DATABASE IF EXISTS {self._DST_DB}")
+        admin_conn.execute(f"DROP DATABASE IF EXISTS {self._dst_db}")
         admin_conn.close()
 
 


### PR DESCRIPTION
## Problem

`PGJsonbRecoveryHP` built the destination storage DSN with:

```python
dst_dsn = DSN.replace("dbname=zodb_test", f"dbname={self._DST_DB}")
```

That literal match silently **no-ops** for any DSN whose dbname is not exactly `zodb_test` (e.g. running with `ZODB_TEST_DSN="... dbname=zodb ..."`). The destination storage then points at the **same** database as the source, and the recovery tests (`testSimpleRecovery`, `testRestoreAcrossPack`, `testRestoreWithMultipleUndoRedo`, `testRestoreWithMultipleObjectsInUndoRedo`, `testPackWithGCOnDestinationAfterRestore`) fail mid-run with a confusing:

```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "transaction_log_pkey"
```

instead of a clear "your DSN isn't isolated" signal. This is a test-harness fragility only — there is no product bug.

## Fix

- Parse the source dbname out of the DSN, name the destination `<src>_dst`, and substitute it with a regex so any libpq `key=value` DSN works (not just `dbname=zodb_test`).
- Assert the destination DSN is distinct from the source, so any future DSN form that breaks the derivation fails loudly rather than silently colliding.

## Verification

The 5 `PGJsonbRecoveryHP` tests pass with **both**:
- the canonical `dbname=zodb_test` DSN, and
- a `dbname=zodb` override (which previously produced the duplicate-key failures).

Full conformance suite: 80 passed. Full test suite: 533 passed, 0 failures. `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)