### PR TITLE
Release 1.13.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,19 +1,6 @@
 # Changelog
 
-## unreleased
-
-### Tests
-
-- **Recovery conformance: robust destination DSN derivation.**
-  `PGJsonbRecoveryHP` built the destination DSN via
-  `DSN.replace("dbname=zodb_test", ...)`, which silently no-ops for any
-  DSN whose dbname is not literally `zodb_test` (e.g. a `ZODB_TEST_DSN`
-  with `dbname=zodb`), leaving source and destination on the same
-  database and producing confusing `transaction_log_pkey` duplicate-key
-  failures.  The destination dbname is now derived from the source DSN
-  (`<src>_dst`) via regex and asserted distinct, so the tests work with
-  any libpq key=value DSN and a broken derivation fails loudly.
-
+## 1.13.1
 
 ### Bugfixes
 
@@ -39,8 +26,20 @@
   1 GB), which now applies with or without S3.  The per-instance temp
   dir is retained only for transient write-staging.  On startup the
   storage also sweeps orphaned `zodb-pgjsonb-blobs-*` dirs left by
-  pre-1.14 workers (conservatively: never its own, only dirs older than
-  an hour).
+  pre-1.13.1 workers (conservatively: never its own, only dirs older
+  than an hour).
+
+### Tests
+
+- **Recovery conformance: robust destination DSN derivation.**
+  `PGJsonbRecoveryHP` built the destination DSN via
+  `DSN.replace("dbname=zodb_test", ...)`, which silently no-ops for any
+  DSN whose dbname is not literally `zodb_test` (e.g. a `ZODB_TEST_DSN`
+  with `dbname=zodb`), leaving source and destination on the same
+  database and producing confusing `transaction_log_pkey` duplicate-key
+  failures.  The destination dbname is now derived from the source DSN
+  (`<src>_dst`) via regex and asserted distinct, so the tests work with
+  any libpq key=value DSN and a broken derivation fails loudly.
 
 ## 1.13.0
 

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -1475,7 +1475,7 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
     def _sweep_orphan_blob_dirs(self):
         """Delete orphaned "zodb-pgjsonb-blobs-*" dirs from dead workers.
 
-        Pre-1.14 instances materialized read blobs into per-instance
+        Pre-1.13.1 instances materialized read blobs into per-instance
         mkdtemp dirs that were only removed on a clean close(); abnormal
         termination (pod eviction/crash) leaked them entirely (#71).
         Sweep them on startup, but conservatively: never touch our own


### PR DESCRIPTION
Finalize the changelog for **1.13.1**.

Promotes the `## unreleased` section to `## 1.13.1` and corrects the orphan-sweep version reference (`pre-1.14` → `pre-1.13.1`). No functional code changes beyond a docstring.

Contents of 1.13.1:
- **#71** — bound the per-instance blob materialization dir (fixes unbounded local-disk growth / `DiskPressure`); read blobs now go through a process-wide bounded cache (PR #72).
- Recovery conformance test: robust destination-DSN derivation (PR #73).

After merge: tag `v1.13.1` on main and publish the GitHub release to trigger the PyPI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)