### PR TITLE
docs(ecosystem): add cdk8s-plone to the ecosystem dashboard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ### Documentation
 
+- Add `cdk8s-plone` to the ecosystem dashboard under a new `Deployment`
+  group, covering Kubernetes deployment of Plone backend and frontend.
+
 - Add `RELEASE.md` documenting the tag-based (`hatch-vcs`) release
   process: finalize `CHANGES.md`, merge via release PR, tag `vX.Y.Z`,
   and publish a GitHub release to trigger the PyPI upload.

--- a/docs/sources/ecosystem.md
+++ b/docs/sources/ecosystem.md
@@ -37,6 +37,12 @@ layout: landing
   group: Image Processing
   description: Thumbor blob loader for zodb-pgjsonb
 
+- repo: bluedynamics/cdk8s-plone
+  pypi: cdk8s-plone
+  docs: https://bluedynamics.github.io/cdk8s-plone/
+  group: Deployment
+  description: Deploy Plone backend and frontend to Kubernetes with cdk8s
+
 - repo: bluedynamics/zodb-json-codec
   pypi: zodb-json-codec
   docs: https://bluedynamics.github.io/zodb-json-codec/


### PR DESCRIPTION
Adds **cdk8s-plone** to the ecosystem dashboard under a new `Deployment` group, covering Kubernetes deployment of the Plone backend and frontend.

The card links GitHub / PyPI / docs and shows the live PyPI version + GitHub issue/PR counts like the others. CHANGES.md updated.

Companion PR in cdk8s-plone aligns its docs theme and adds the reciprocal `Ecosystem` nav menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)