### PR TITLE
docs(ecosystem): add cdk8s-plone to the Ecosystem nav dropdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 - Add `cdk8s-plone` to the ecosystem dashboard under a new `Deployment`
   group, covering Kubernetes deployment of Plone backend and frontend.
 
+- Add `cdk8s-plone` to the ecosystem navigation dropdown.
+
 - Add `RELEASE.md` documenting the tag-based (`hatch-vcs`) release
   process: finalize `CHANGES.md`, merge via release PR, tag `vX.Y.Z`,
   and publish a GitHub release to trigger the PyPI upload.

--- a/docs/sources/conf.py
+++ b/docs/sources/conf.py
@@ -77,6 +77,11 @@ html_theme_options = {
                     "url": "https://bluedynamics.github.io/plone-pgthumbor/",
                     "summary": "Thumbor image scaling",
                 },
+                {
+                    "title": "cdk8s-plone",
+                    "url": "https://bluedynamics.github.io/cdk8s-plone/",
+                    "summary": "Deploy Plone to Kubernetes",
+                },
             ],
         },
         {


### PR DESCRIPTION
Adds cdk8s-plone to the `Ecosystem` navigation dropdown so the menu stays symmetric across all ecosystem packages (companion to the dashboard card merged in #76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)