### PR TITLE
feat(storage): gate startup DDL behind a double-checked schema-version probe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,28 @@
 
 ## unreleased
 
+### Features
+
+- **Gate startup DDL behind a double-checked schema-version probe** (#78).
+  On a rolling deploy every replica used to enter `_apply_pending_ddl()`,
+  take the `startup_ddl_lock` advisory lock, and re-run the full idempotent
+  DDL batch even when the schema was already current — so all N pods
+  connected and waited on the lock, saturating the DB during the migration
+  window (downstream symptom: bluedynamics/plone-pgcatalog#136).
+
+  Deferred DDL/actions now carry a version marker recorded in a new
+  `pgjsonb_schema_state` table.  A cheap `SELECT` runs *before* the lock, so
+  replicas whose tagged work is already current bail out without ever
+  contending for it; the check is repeated *inside* the lock to cover the
+  race where another replica applies while we wait.  The static
+  `get_schema_sql()` block is gated automatically (its version is the
+  `sha256` of the DDL), and `defer_startup_action()` gained an optional
+  `version` argument for deferred callables.  Untagged work (`version=None`)
+  still runs under the lock on every startup, as before.
+
+  Set `ZODB_PGJSONB_FORCE_DDL=1` to bypass the gate and force a full run
+  (e.g. after a manual index drop).
+
 ### Documentation
 
 - Add `cdk8s-plone` to the ecosystem dashboard under a new `Deployment`

--- a/docs/sources/explanation/architecture.md
+++ b/docs/sources/explanation/architecture.md
@@ -130,6 +130,35 @@ Within the lock, `_new_tid()` generates a timestamp-based TID that is guaranteed
 This is a simplicity trade-off: it limits write throughput to one transaction at a time, but guarantees correct TID ordering without complex distributed coordination.
 For most ZODB workloads, write transactions are short and the advisory lock introduces negligible contention.
 
+(startup-ddl-gate)=
+
+## Startup DDL and the schema-version gate
+
+State processors (and plugins like plone-pgcatalog) contribute schema DDL — new columns, indexes, statistics — that must exist before the first request.
+This DDL cannot run while a ZODB connection holds an open `REPEATABLE READ` snapshot, because `CREATE INDEX` needs `ACCESS EXCLUSIVE` and would deadlock against the snapshot's `ACCESS SHARE`.
+So the storage defers it: `register_state_processor()` and `defer_startup_action()` queue the work, and `_apply_pending_ddl()` runs it from the first write transaction, once the snapshot has been released.
+
+A single replica applying idempotent DDL is cheap.
+The problem is a rolling deploy of many replicas.
+Each pod boots, queues the same DDL, and serializes on a session-level advisory lock (`startup_ddl_lock`) so only one actually runs it.
+The DDL is idempotent (`CREATE INDEX IF NOT EXISTS`), so the losers do no real work — but they still *connect and wait on the lock*, holding idle-in-transaction connections for the whole migration window.
+On a large catalog that was enough to saturate the database and cascade into failed health checks (issue #78).
+
+The fix is the classic double-checked locking pattern, keyed by a schema version.
+Each deferred entry carries a version string, and the storage records which version it last applied per source in a small `pgjsonb_schema_state` table.
+Before taking the lock, a pod runs one cheap `SELECT` against that table.
+If every tagged entry is already current, the pod returns immediately and never touches the lock — so on a warm cluster N−1 replicas bail out in a single round-trip.
+The check is repeated *inside* the lock, because between the probe and acquiring the lock another replica may have applied the DDL; the winner re-reads the markers and skips anything already done.
+
+Two version sources feed the gate.
+The static `get_schema_sql()` block is hashed automatically (`sha256` of the DDL text), so it re-applies exactly when the DDL changes and needs no cooperation from the processor.
+Deferred callables pass an explicit `version` to `defer_startup_action()`, because their effect depends on runtime state (such as the live index registry) that no hash of static text would capture.
+Entries with `version=None` are always treated as stale and run under the lock on every startup, which preserves the original behavior for callers that have not opted in.
+
+This trades one property for another.
+The gate *trusts the marker* instead of re-checking the live schema, so if someone manually drops an index, the idempotent DDL that would have recreated it is skipped until the version changes.
+That trade is deliberate — skipping the redundant DDL is the entire point — and `ZODB_PGJSONB_FORCE_DDL=1` is the escape hatch when you need a full re-apply.
+
 ## Connection pool lifecycle
 
 zodb-pgjsonb uses psycopg3's `ConnectionPool` for all database connections.

--- a/docs/sources/how-to/deploy-production.md
+++ b/docs/sources/how-to/deploy-production.md
@@ -40,6 +40,26 @@ The cache stores pickle bytes keyed by object ID, avoiding repeated PostgreSQL r
 The default is 16 MB.
 Set to 0 to disable caching entirely.
 
+## Roll out without a DDL stampede
+
+When you run several replicas and deploy with a rolling update, every pod starts up and wants to apply its deferred schema DDL.
+The storage coordinates this with a session-level advisory lock so only one pod runs the DDL at a time.
+A schema-version gate runs a cheap `SELECT` *before* taking that lock, so replicas whose DDL is already current return immediately instead of all queuing on the lock.
+
+You do not need to configure anything for this — it is on by default.
+The first deploy after upgrading records the version markers; from then on, deploys that do not change the schema skip the lock entirely.
+
+Two environment variables let you tune the behavior:
+
+- Set `ZODB_PGJSONB_DDL_LOCK_TIMEOUT` (default `15min`) to bound how long a pod waits for the lock before requeuing its DDL for the next transaction.
+- Set `ZODB_PGJSONB_FORCE_DDL=1` on a single pod to bypass the gate and re-apply all deferred DDL, for example after you manually dropped an index.
+  Remove it again once that pod has started, so the rest of the fleet keeps using the fast path.
+
+```{seealso}
+{ref}`startup-ddl-gate` explains how the gate works and why it trades re-running idempotent DDL for skipping the lock.
+For the variables themselves, see {doc}`/reference/configuration`.
+```
+
 ## Schedule periodic pack
 
 Pack removes unreachable objects (history-free mode) or old revisions (history-preserving mode).

--- a/docs/sources/llms.txt
+++ b/docs/sources/llms.txt
@@ -176,6 +176,13 @@ class IStateProcessor:
 
 Used by plone-pgcatalog to write catalog index columns in the same PG transaction.
 
+Processor `get_schema_sql()` DDL and `defer_startup_action()` callables run from
+the first write transaction under a session-level advisory lock. A double-checked
+schema-version gate (markers in `pgjsonb_schema_state`) lets replicas skip the
+lock when their tagged DDL is already current: the static DDL block is auto-tagged
+by `sha256`, deferred actions pass an explicit `version`, and `version=None` always
+runs. `ZODB_PGJSONB_FORCE_DDL=1` forces a full re-apply.
+
 ## Configuration (ZConfig)
 
 ```xml

--- a/docs/sources/reference/configuration.md
+++ b/docs/sources/reference/configuration.md
@@ -92,6 +92,20 @@ The ZConfig factory (`PGJsonbStorageFactory`) constructs `S3Client` and
 | Tiered | `s3-bucket-name` set, `blob-threshold` > 0 | Blobs smaller than threshold stored in PG bytea; blobs at or above threshold stored in S3 with key in `blob_state.s3_key`. |
 | S3-only | `s3-bucket-name` set, `blob-threshold` = 0 | All blobs stored in S3. |
 
+## Environment variables
+
+These variables tune startup-DDL coordination across replicas.
+They are read from the process environment, not from ZConfig.
+
+| Variable | Default | Description |
+|---|---|---|
+| `ZODB_PGJSONB_DDL_LOCK_TIMEOUT` | `15min` | `lock_timeout` applied while acquiring the startup DDL advisory lock. Accepts any PostgreSQL interval literal (for example `30s`, `5min`). On timeout the pending DDL is requeued and retried on the next transaction. |
+| `ZODB_PGJSONB_FORCE_DDL` | unset | When set to any non-empty value, bypasses the schema-version gate and forces a full deferred-DDL run under the lock. Use it after a manual index drop or to re-apply DDL that the version markers consider current. |
+
+```{versionadded} 1.14
+`ZODB_PGJSONB_FORCE_DDL` and the schema-version gate it controls.
+```
+
 ## Dependencies
 
 ### Required

--- a/src/zodb_pgjsonb/schema.py
+++ b/src/zodb_pgjsonb/schema.py
@@ -119,6 +119,28 @@ def _set_lz4_compression(conn):
                 conn.rollback()
 
 
+SCHEMA_STATE_TABLE = """\
+CREATE TABLE IF NOT EXISTS pgjsonb_schema_state (
+    source     text PRIMARY KEY,
+    version    text NOT NULL,
+    applied_at timestamptz NOT NULL DEFAULT now()
+);
+"""
+
+
+def _ensure_schema_state_table(conn):
+    """Create the ``pgjsonb_schema_state`` marker table.
+
+    Records, per deferred-DDL source, the version that has been applied so
+    that ``_apply_pending_ddl`` can skip the startup advisory lock when the
+    schema is already current (issue #78).  ``CREATE TABLE IF NOT EXISTS`` on
+    a brand-new table name takes no lock that conflicts with REPEATABLE READ
+    snapshots on other tables, so this is safe to run on every startup.
+    """
+    conn.execute(SCHEMA_STATE_TABLE)
+    conn.commit()
+
+
 def _ensure_zoid_seq(conn):
     """Create or synchronize the zoid_seq sequence.
 
@@ -201,6 +223,9 @@ def install_schema(conn, *, history_preserving=False):
 
     # OID sequence for cross-process uniqueness (#31).
     _ensure_zoid_seq(conn)
+
+    # Startup-DDL version markers for the double-checked gate (#78).
+    _ensure_schema_state_table(conn)
 
 
 def drop_history_tables(conn):

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -50,6 +50,7 @@ from ZODB.utils import z64
 
 import contextlib
 import dataclasses
+import hashlib
 import logging
 import os
 import psycopg
@@ -687,7 +688,10 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
         - ``get_schema_sql() -> str | None``
           Return DDL to apply (e.g. ALTER TABLE, CREATE INDEX).  Applied
           via a separate autocommit connection.  If blocked by startup
-          read transactions, deferred to the first tpc_begin().
+          read transactions, deferred to the first tpc_begin().  The DDL is
+          version-tagged automatically (``sha256`` of the returned text) so
+          the startup schema-version gate skips it — and the startup
+          advisory lock — when it has not changed since the last apply (#78).
 
         ``process`` may modify *state* in-place (e.g. pop annotation keys).
         It returns a dict of ``{column_name: value}`` to be written as extra
@@ -754,9 +758,10 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
             "DDL from %s deferred to first write transaction.",
             processor_name,
         )
-        self._pending_ddl.append((sql, processor_name))
+        version = "sha256:" + hashlib.sha256(sql.encode("utf-8")).hexdigest()
+        self._pending_ddl.append((sql, processor_name, version))
 
-    def defer_startup_action(self, action, name):
+    def defer_startup_action(self, action, name, version=None):
         """Defer a callable to be executed on the first write transaction.
 
         Like ``_apply_processor_ddl`` but accepts an arbitrary callable
@@ -766,9 +771,77 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
         Used by plugins (e.g. plone-pgcatalog) to defer index creation
         that would deadlock against open REPEATABLE READ snapshots at
         startup.
+
+        Pass *version* (a string that changes whenever the action's effect
+        changes, e.g. a hash of the index list it would create) to let the
+        double-checked schema-version gate skip this action — and the
+        startup advisory lock — when it has already been applied (#78).
+        When *version* is ``None`` the action runs on every startup, holding
+        the lock, as before.
         """
         logger.info("Startup action '%s' deferred to first write transaction.", name)
-        self._pending_ddl.append((action, name))
+        self._pending_ddl.append((action, name, version))
+
+    def _read_schema_state(self, conn=None):
+        """Return ``{source: version}`` from ``pgjsonb_schema_state``.
+
+        Tolerates the table being absent (very first deploy / probe race)
+        by returning ``{}`` so every tagged source is treated as stale.
+        When *conn* is given (the startup lock's autocommit connection) it
+        is reused; otherwise a short-lived autocommit connection is opened.
+        """
+        own = conn is None
+        if own:
+            conn = psycopg.connect(self._dsn, autocommit=True)
+            conn.execute("SET statement_timeout = '5s'")
+        try:
+            with conn.cursor() as cur:
+                try:
+                    cur.execute("SELECT source, version FROM pgjsonb_schema_state")
+                except psycopg.errors.UndefinedTable:
+                    return {}
+                rows = cur.fetchall()
+            state = {}
+            for row in rows:
+                if isinstance(row, dict):
+                    state[row["source"]] = row["version"]
+                else:
+                    state[row[0]] = row[1]
+            return state
+        finally:
+            if own:
+                conn.close()
+
+    def _filter_stale(self, pending, conn=None):
+        """Return the pending entries that still need applying.
+
+        An entry is stale when its version is ``None`` (always run) or when
+        the recorded marker differs from the entry's version.  Skips reading
+        the marker table entirely when nothing is version-tagged.
+        """
+        if not any(version is not None for _, _, version in pending):
+            return list(pending)
+        applied = self._read_schema_state(conn)
+        return [
+            entry
+            for entry in pending
+            if entry[2] is None or applied.get(entry[1]) != entry[2]
+        ]
+
+    def _mark_schema_applied(self, conn, name, version):
+        """Record that *name* has been applied at *version* (best effort)."""
+        try:
+            conn.execute(
+                "INSERT INTO pgjsonb_schema_state (source, version) "
+                "VALUES (%s, %s) "
+                "ON CONFLICT (source) DO UPDATE "
+                "SET version = EXCLUDED.version, applied_at = now()",
+                (name, version),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to record schema version marker for %s", name, exc_info=True
+            )
 
     def _apply_pending_ddl(self):
         """Apply deferred DDL and startup actions.
@@ -776,20 +849,60 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
         Called from ``tpc_begin()`` / ``_begin()`` after the read
         transaction is committed (ACCESS SHARE released).
 
-        Each entry is either ``(sql_string, name)`` or
-        ``(callable, name)``.  Callables receive ``self._dsn``.
+        Each entry is ``(action, name, version)`` where *action* is a SQL
+        string or a callable receiving ``self._dsn``, and *version* is a
+        marker string or ``None``.
 
-        Wraps the whole batch in a session-level PG advisory lock so
-        concurrent replicas serialize their DDL.  On lock timeout, the
+        Uses a double-checked schema-version gate around the session-level
+        advisory lock (#78): a cheap marker probe runs *before* the lock so
+        replicas whose tagged work is already current bail without ever
+        contending for the lock; the check is repeated *inside* the lock in
+        case another replica applied while we waited.  ``ZODB_PGJSONB_FORCE_DDL``
+        bypasses both checks and forces a full run.  On lock timeout the
         pending entries are requeued for the next call.
         """
         if not self._pending_ddl:
             return
         pending = self._pending_ddl[:]
         self._pending_ddl.clear()
+
+        force = bool(os.environ.get("ZODB_PGJSONB_FORCE_DDL"))
+
+        # Cheap probe before the lock — loser replicas bail out here.
+        if force:
+            stale = pending
+        else:
+            try:
+                stale = self._filter_stale(pending)
+            except Exception:
+                # Probe failed (DB hiccup) — fall back to the safe path of
+                # taking the lock and letting the in-lock re-check decide.
+                logger.warning(
+                    "Startup schema-version probe failed — taking the DDL lock",
+                    exc_info=True,
+                )
+                stale = pending
+            if not stale:
+                logger.debug(
+                    "Startup schema current on all %d pending source(s) — "
+                    "skipping startup DDL lock",
+                    len(pending),
+                )
+                return
+
         try:
-            with startup_ddl_lock(self._dsn):
-                for action, name in pending:
+            with startup_ddl_lock(self._dsn) as lock_conn:
+                # Re-check under the lock: another replica may have applied
+                # while we waited.
+                if not force:
+                    stale = self._filter_stale(pending, conn=lock_conn)
+                    if not stale:
+                        logger.info(
+                            "Startup schema applied by another replica while "
+                            "waiting for the DDL lock — nothing to do",
+                        )
+                        return
+                for action, name, version in stale:
                     try:
                         if callable(action):
                             action(self._dsn)
@@ -799,6 +912,8 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
                             ) as ddl_conn:
                                 ddl_conn.execute("SET lock_timeout = '30s'")
                                 ddl_conn.execute(action)
+                        if version is not None:
+                            self._mark_schema_applied(lock_conn, name, version)
                         logger.info("Applied deferred DDL/action from %s", name)
                     except Exception:
                         logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ DSN = get_test_dsn()
 
 # All tables that may exist across history-free and history-preserving modes.
 ALL_TABLES = (
+    "pgjsonb_schema_state",
     "cache_warm_stats",
     "migration_watermark",
     "pack_state",

--- a/tests/test_startup_ddl_gate.py
+++ b/tests/test_startup_ddl_gate.py
@@ -1,0 +1,205 @@
+"""Tests for the double-checked schema-version gate around startup DDL.
+
+See issue bluedynamics/zodb-pgjsonb#78: loser replicas must bail out of
+``_apply_pending_ddl`` with one cheap SELECT before taking the advisory lock.
+"""
+
+import psycopg
+import pytest
+
+
+pytestmark = pytest.mark.db
+
+
+def _table_exists(name):
+    from tests.conftest import DSN
+
+    conn = psycopg.connect(DSN)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT to_regclass(%s) IS NOT NULL AS ok", (name,))
+            row = cur.fetchone()
+            return row["ok"] if isinstance(row, dict) else row[0]
+    finally:
+        conn.close()
+
+
+def test_install_schema_creates_marker_table(storage):
+    """install_schema (run by the storage constructor) creates the
+    pgjsonb_schema_state marker table."""
+    assert _table_exists("pgjsonb_schema_state")
+
+
+class _SchemaProcessor:
+    """Minimal state processor exposing a static DDL block."""
+
+    SQL = "CREATE INDEX IF NOT EXISTS idx_gate_test ON object_state (zoid);"
+
+    def get_extra_columns(self):
+        return []
+
+    def process(self, zoid, class_mod, class_name, state):
+        return None
+
+    def get_schema_sql(self):
+        return self.SQL
+
+
+def test_processor_ddl_tagged_with_sha256_version(storage):
+    """register_state_processor stores a 3-tuple whose version is the
+    sha256 of the processor's get_schema_sql() output."""
+    import hashlib
+
+    storage.register_state_processor(_SchemaProcessor())
+
+    entries = [e for e in storage._pending_ddl if e[1] == "_SchemaProcessor"]
+    assert len(entries) == 1
+    action, _name, version = entries[0]
+    assert action == _SchemaProcessor.SQL
+    expected = "sha256:" + hashlib.sha256(_SchemaProcessor.SQL.encode()).hexdigest()
+    assert version == expected
+
+
+def test_defer_startup_action_passes_version_through(storage):
+    """defer_startup_action records the supplied version; defaults to None."""
+
+    def _noop(dsn):
+        return None
+
+    storage.defer_startup_action(_noop, "tagged", version="v1")
+    storage.defer_startup_action(_noop, "untagged")
+
+    by_name = {name: version for _, name, version in storage._pending_ddl}
+    assert by_name["tagged"] == "v1"
+    assert by_name["untagged"] is None
+
+
+def _read_marker(source):
+    from tests.conftest import DSN
+
+    conn = psycopg.connect(DSN)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT version FROM pgjsonb_schema_state WHERE source = %s",
+                (source,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            return row["version"] if isinstance(row, dict) else row[0]
+    finally:
+        conn.close()
+
+
+def test_gate_skips_action_when_version_current(storage):
+    """A tagged action runs once and records its version; a second
+    _apply_pending_ddl with the same version skips it (no re-run)."""
+    calls = []
+
+    def _action(dsn):
+        calls.append(1)
+
+    storage.defer_startup_action(_action, "counter", version="v1")
+    storage._apply_pending_ddl()
+    assert calls == [1]
+    assert _read_marker("counter") == "v1"
+
+    # Same version again → gate bails, action not re-invoked.
+    storage.defer_startup_action(_action, "counter", version="v1")
+    storage._apply_pending_ddl()
+    assert calls == [1]
+
+
+def test_gate_reruns_action_when_version_changes(storage):
+    """A changed version makes the action stale again → it re-runs and
+    the marker is updated."""
+    calls = []
+
+    def _action(dsn):
+        calls.append(1)
+
+    storage.defer_startup_action(_action, "counter", version="v1")
+    storage._apply_pending_ddl()
+    assert calls == [1]
+
+    storage.defer_startup_action(_action, "counter", version="v2")
+    storage._apply_pending_ddl()
+    assert calls == [1, 1]
+    assert _read_marker("counter") == "v2"
+
+
+def test_untagged_action_always_runs_and_is_not_marked(storage):
+    """version=None entries always run (today's behavior) and write no marker."""
+    calls = []
+
+    def _action(dsn):
+        calls.append(1)
+
+    storage.defer_startup_action(_action, "untagged", version=None)
+    storage._apply_pending_ddl()
+    storage.defer_startup_action(_action, "untagged", version=None)
+    storage._apply_pending_ddl()
+    assert calls == [1, 1]
+    assert _read_marker("untagged") is None
+
+
+def test_gate_tolerates_missing_marker_table(storage):
+    """If the marker table is absent (first deploy / probe race), the gate
+    treats everything as stale, runs the action, and does not crash."""
+    from tests.conftest import DSN
+
+    conn = psycopg.connect(DSN, autocommit=True)
+    conn.execute("DROP TABLE IF EXISTS pgjsonb_schema_state")
+    conn.close()
+
+    calls = []
+
+    def _action(dsn):
+        calls.append(1)
+
+    storage.defer_startup_action(_action, "counter", version="v1")
+    storage._apply_pending_ddl()
+    assert calls == [1]
+
+
+def test_force_ddl_env_bypasses_gate(storage, monkeypatch):
+    """ZODB_PGJSONB_FORCE_DDL re-runs a tagged action even when current."""
+    calls = []
+
+    def _action(dsn):
+        calls.append(1)
+
+    storage.defer_startup_action(_action, "counter", version="v1")
+    storage._apply_pending_ddl()
+    assert calls == [1]
+
+    monkeypatch.setenv("ZODB_PGJSONB_FORCE_DDL", "1")
+    storage.defer_startup_action(_action, "counter", version="v1")
+    storage._apply_pending_ddl()
+    assert calls == [1, 1]
+
+
+def test_in_lock_recheck_bails_when_other_replica_applied(storage, monkeypatch):
+    """When the marker turns current between the pre-lock probe and the
+    in-lock re-check, the action is skipped (no duplicate work)."""
+    calls = []
+
+    def _action(dsn):
+        calls.append(1)
+
+    storage.defer_startup_action(_action, "counter", version="v1")
+
+    state = {"n": 0}
+
+    def fake_filter(pending, conn=None):
+        state["n"] += 1
+        # First call = pre-lock probe (stale); second = in-lock re-check
+        # (another replica applied while we waited → nothing left).
+        return list(pending) if state["n"] == 1 else []
+
+    monkeypatch.setattr(storage, "_filter_stale", fake_filter)
+
+    storage._apply_pending_ddl()
+    assert calls == []
+    assert state["n"] == 2

--- a/tests/test_startup_ddl_serialization.py
+++ b/tests/test_startup_ddl_serialization.py
@@ -34,7 +34,7 @@ def test_apply_pending_ddl_serializes_across_threads():
                 finished.append(time.monotonic())
 
         def worker():
-            storage._pending_ddl.append((slow_action, "slow"))
+            storage._pending_ddl.append((slow_action, "slow", None))
             barrier.wait()
             storage._apply_pending_ddl()
 
@@ -78,7 +78,7 @@ def test_apply_pending_ddl_requeues_on_lock_timeout():
             def noop_action(dsn):
                 pass
 
-            storage._pending_ddl.append((noop_action, "noop"))
+            storage._pending_ddl.append((noop_action, "noop", None))
 
             # Force a very short timeout via env var.
             old = os.environ.get("ZODB_PGJSONB_DDL_LOCK_TIMEOUT")


### PR DESCRIPTION
## Why

On a rolling deploy, **every** replica entered `_apply_pending_ddl()`, took the `startup_ddl_lock` advisory lock, and re-ran the full idempotent DDL batch — even when the schema was already current. The lock serialized correctly, but all N pods still connected and **waited on the lock**, tying up DB connections and CPU for the whole migration window when only one pod did real work.

Observed in production (6 backend pods, 3.9M-row catalog; downstream symptom bluedynamics/plone-pgcatalog#136): the losers held idle-in-transaction connections, the DB primary saturated, `/ok` probes timed out, and Varnish marked backends sick → 503 cascade.

Closes #78.

## What

A double-checked schema-version gate around the advisory lock:

- New `pgjsonb_schema_state(source, version, applied_at)` table, created in `install_schema()` (fresh-install **and** existing-DB paths; the probe tolerates it being absent).
- `_pending_ddl` entries become `(action, name, version)`.
  - The static `get_schema_sql()` block is **auto-tagged** with `sha256` of its DDL — no processor change needed.
  - `defer_startup_action(action, name, version=None)` gained an optional `version` for deferred callables.
  - `version=None` is always treated as stale → runs under the lock on every startup, preserving today's behavior.
- `_apply_pending_ddl()` runs a cheap `SELECT` **before** the lock (loser replicas bail without contending), then re-checks **inside** the lock to cover the probe→lock race, recording each applied version on the lock's connection.
- `ZODB_PGJSONB_FORCE_DDL=1` bypasses both checks and forces a full re-apply (escape hatch after a manual index drop).

### Trade-off

The gate trusts the marker over the live schema, so a manually dropped index is not recreated until the version changes. That is deliberate — skipping the redundant DDL is the point — and `ZODB_PGJSONB_FORCE_DDL` is the escape hatch.

## Tests

New `tests/test_startup_ddl_gate.py` (9 tests): marker table creation, sha256 tagging, version pass-through, skip-when-current, re-run-on-change, untagged-always-runs, missing-table tolerance, `FORCE_DDL` bypass, and the in-lock re-check. Existing 2-tuple DDL tests migrated to `version=None`.

Full suite: 544 passed; `ruff check` / `ruff format --check` clean; docs build with zero warnings on the changed pages.

## Docs

- Reference: `ZODB_PGJSONB_FORCE_DDL` + `ZODB_PGJSONB_DDL_LOCK_TIMEOUT` in `reference/configuration.md`.
- How-to: "Roll out without a DDL stampede" in `how-to/deploy-production.md`.
- Explanation: schema-version gate section in `explanation/architecture.md`.
- `llms.txt`, docstrings, and a `CHANGES.md` entry.

## Follow-up (not in this PR)

plone-pgcatalog should tag its three `defer_startup_action()` calls (`ensure_text_indexes`, `ensure_field_indexes`, `analyze_object_state`) with versions so loser pods bail **completely**. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)