### PR TITLE
fix(instance): don't leak pool slot on server-closed conn; silence lz4 startup ERROR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## unreleased
+
+### Bugfixes
+
+- **Don't leak a pool slot when a connection is closed server-side** (#81).
+  `_end_read_txn()` ran `COMMIT` unguarded, so when PostgreSQL terminated an
+  idle-in-transaction connection (e.g. via `idle_in_transaction_session_timeout`)
+  the next read-only request raised through `poll_invalidations` (HTTP 500) and,
+  worse, `release()` raised *before* `putconn()` — leaking the pool slot. After
+  ~`pool-max-size` such leaks the pool was permanently exhausted (`PoolTimeout`)
+  and the pod never became ready again, stalling rolling deploys. `_end_read_txn()`
+  now clears its flag and swallows the failed `COMMIT`, and `release()` always
+  returns the connection to the pool (the pool discards the dead one and opens a
+  replacement).
+
+- **Stop logging a spurious `42P01` ERROR on every startup** (#82). In
+  non-history-preserving mode `_set_lz4_compression()` issued
+  `ALTER TABLE object_history …` for a table that never exists, which PostgreSQL
+  logged as a server-side ERROR on every pod startup (red noise in CNPG
+  dashboards) even though the client caught and rolled it back. Each table is now
+  probed with `to_regclass` first and skipped if absent, so no failing statement
+  is sent.
+
 ## 1.14.0
 
 ### Features

--- a/src/zodb_pgjsonb/instance.py
+++ b/src/zodb_pgjsonb/instance.py
@@ -106,11 +106,27 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
         return self._main.new_instance()
 
     def release(self):
-        """Return connection to pool and clean up temp dir."""
-        if self._conn and not self._conn.closed:
-            self._end_read_txn()
-            self._instance_pool.putconn(self._conn)
-            self._conn = None
+        """Return connection to pool and clean up temp dir.
+
+        Always returns the connection to the pool — even if ending the read
+        transaction fails — so a connection killed server-side (e.g. by
+        ``idle_in_transaction_session_timeout``) cannot leak its pool slot
+        and eventually exhaust the pool (``PoolTimeout``), wedging the pod
+        (#81).  Returning a broken connection is safe: the pool discards it
+        and opens a replacement.
+        """
+        if self._conn is not None:
+            try:
+                self._end_read_txn()
+            finally:
+                try:
+                    self._instance_pool.putconn(self._conn)
+                except Exception:
+                    logger.warning(
+                        "release: returning connection to pool failed",
+                        exc_info=True,
+                    )
+                self._conn = None
         if os.path.exists(self._blob_temp_dir):
             shutil.rmtree(self._blob_temp_dir, ignore_errors=True)
 
@@ -140,10 +156,26 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
         self._serial_cache.clear()
 
     def _end_read_txn(self):
-        """End the current REPEATABLE READ snapshot transaction, if any."""
-        if self._in_read_txn:
+        """End the current REPEATABLE READ snapshot transaction, if any.
+
+        Resilient to the connection having been closed server-side (e.g. by
+        ``idle_in_transaction_session_timeout`` or an operator): the flag is
+        cleared first, then any error from the ``COMMIT`` is swallowed so no
+        caller (``release``, ``poll_invalidations``, ``tpc_begin``) has to
+        guard it (#81).  The dead connection is recycled by the pool on the
+        next ``release``/``putconn``.
+        """
+        if not self._in_read_txn:
+            return
+        self._in_read_txn = False
+        try:
             self._conn.execute("COMMIT")
-            self._in_read_txn = False
+        except Exception:
+            logger.warning(
+                "_end_read_txn: COMMIT failed (connection likely closed "
+                "server-side); the pool will recycle it",
+                exc_info=True,
+            )
 
     def _begin_read_txn(self):
         """Start a REPEATABLE READ snapshot transaction for consistent reads.

--- a/src/zodb_pgjsonb/schema.py
+++ b/src/zodb_pgjsonb/schema.py
@@ -102,6 +102,14 @@ def _set_lz4_compression(conn):
         ("blob_state", "data"),
     ]
     for table, column in columns:
+        # Probe first: object_history exists only in history-preserving mode.
+        # to_regclass returns NULL for an absent relation without raising, so
+        # we never send a failing ALTER that PG logs as a server-side ERROR
+        # on every startup (#82).
+        row = conn.execute("SELECT to_regclass(%s) AS reg", (table,)).fetchone()
+        reg = row["reg"] if isinstance(row, dict) else row[0]
+        if reg is None:
+            continue
         try:
             conn.execute("SET lock_timeout = '5s'")
             conn.execute(

--- a/tests/test_idle_in_xact.py
+++ b/tests/test_idle_in_xact.py
@@ -130,6 +130,68 @@ def test_after_completion_safe_when_conn_killed():
             storage.close()
 
 
+def _kill_backend(pid):
+    """Terminate a backend pid from a separate session (#81 simulation)."""
+    killer = psycopg.connect(DSN)
+    try:
+        killer.execute("SELECT pg_terminate_backend(%s)", (pid,))
+        killer.commit()
+    finally:
+        killer.close()
+
+
+def test_end_read_txn_resets_flag_when_conn_killed():
+    """_end_read_txn must not raise when PG closed the conn server-side, and
+    must still clear _in_read_txn so the instance isn't wedged (#81)."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0)
+    try:
+        instance = storage.new_instance()
+        try:
+            instance.poll_invalidations()
+            assert instance._in_read_txn is True
+
+            _kill_backend(instance._conn.info.backend_pid)
+
+            instance._end_read_txn()  # must not raise
+            assert instance._in_read_txn is False
+        finally:
+            instance.release()
+    finally:
+        storage.close()
+
+
+def test_release_returns_pool_slot_when_conn_killed_server_side():
+    """release() must not raise and must return the pool slot even when the
+    connection was terminated server-side.  Otherwise the slot leaks and the
+    pool is eventually exhausted (PoolTimeout), wedging the pod (#81)."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(
+        DSN, cache_warm_pct=0, pool_size=1, pool_max_size=1, pool_timeout=5.0
+    )
+    try:
+        instance = storage.new_instance()
+        instance.poll_invalidations()
+        _kill_backend(instance._conn.info.backend_pid)
+
+        instance.release()  # must not raise (was bug #81)
+
+        # With pool_max_size=1, a leaked slot would make this getconn() block
+        # until PoolTimeout.  Success here proves the slot was returned.
+        instance2 = storage.new_instance()
+        try:
+            assert instance2._conn is not None
+            assert instance2.poll_invalidations() == []
+        finally:
+            instance2.release()
+    finally:
+        storage.close()
+
+
 def test_zodb_connection_close_releases_virtualxid():
     """End-to-end: closing a read-only ZODB connection releases its virtualxid.
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,62 @@
+"""Unit tests for schema helpers (no database required)."""
+
+from zodb_pgjsonb.schema import _set_lz4_compression
+
+import psycopg
+
+
+class _FakeResult:
+    def __init__(self, row):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _RecordingConn:
+    """Minimal psycopg-like connection that records executed SQL.
+
+    Emulates ``to_regclass`` (NULL for absent relations) and PostgreSQL's
+    server-side error when ``ALTER TABLE`` targets a missing relation.
+    """
+
+    def __init__(self, present_tables):
+        self.present = set(present_tables)
+        self.executed = []
+        self.altered_absent = []  # relations PG would have logged an ERROR for
+
+    def execute(self, sql, params=None):
+        self.executed.append(sql)
+        stripped = sql.strip().upper()
+        if stripped.startswith("SELECT TO_REGCLASS"):
+            table = params[0]
+            return _FakeResult((table if table in self.present else None,))
+        if stripped.startswith("ALTER TABLE"):
+            table = sql.split()[2]
+            if table not in self.present:
+                self.altered_absent.append(table)
+                raise psycopg.errors.UndefinedTable(
+                    f'relation "{table}" does not exist'
+                )
+        return _FakeResult(None)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def test_lz4_skips_absent_tables_without_issuing_alter():
+    """In non-HP mode object_history is absent; _set_lz4_compression must
+    probe with to_regclass and skip it, never issuing a failing ALTER that
+    PostgreSQL logs as a server-side ERROR (#82)."""
+    conn = _RecordingConn(present_tables={"object_state", "blob_state"})
+
+    _set_lz4_compression(conn)
+
+    assert conn.altered_absent == []
+    assert not any("ALTER TABLE object_history" in sql for sql in conn.executed)
+    # Present tables are still compressed.
+    assert any("ALTER TABLE object_state" in sql for sql in conn.executed)
+    assert any("ALTER TABLE blob_state" in sql for sql in conn.executed)


### PR DESCRIPTION
Two production bugs observed on v1.14.0 during a rolling deploy.

## #81 — pool-slot leak → PoolTimeout → pod stuck 🔴

`_end_read_txn()` ran `COMMIT` without guarding against a connection PostgreSQL had already closed server-side (e.g. via `idle_in_transaction_session_timeout`). Consequences:

- Read-only requests **500** (the error propagated through `poll_invalidations`).
- `release()` called `_end_read_txn()` **before** `putconn()`, so the raise **skipped `putconn()` and leaked the pool slot**. After ~`pool-max-size` leaks the pool was permanently exhausted (`PoolTimeout`) and the pod **never became ready again** → rolling deploy stalls.

**Fix:**
- `_end_read_txn()` clears `_in_read_txn` first, then swallows a failed `COMMIT` (logs a WARNING). This covers all four call sites (`release`, `poll_invalidations`, `tpc_begin`, `afterCompletion`) instead of only `afterCompletion`.
- `release()` now returns the connection to the pool via `try/finally` **unconditionally** — returning a dead connection is safe (the pool discards it and opens a replacement), and the slot can no longer leak.

## #82 — spurious `42P01` ERROR logged on every startup 🟡

In non-history-preserving mode `_set_lz4_compression()` issued `ALTER TABLE object_history …` for a table that only exists in HP mode. The client caught and rolled it back, but PostgreSQL had **already logged a server-side ERROR** — red noise in CNPG dashboards on every pod start that can mask genuine errors.

**Fix:** probe each table with `to_regclass` (returns NULL for an absent relation, no error) and skip it if absent, so no failing statement is ever sent. Handles both `dict_row` and tuple row factories.

## Tests

- `test_idle_in_xact.py`: two new tests using `pg_terminate_backend` to kill the backend server-side — one asserts `_end_read_txn()` resets the flag without raising, one asserts `release()` returns the pool slot (a second `new_instance()` against a `pool_max_size=1` pool succeeds instead of hitting `PoolTimeout`).
- `test_schema.py` (new): asserts `_set_lz4_compression` probes and skips absent tables, never issuing the `object_history` ALTER, while still compressing present tables.

Full suite: **547 passed**. `ruff check` / `ruff format --check` clean.

Closes #81
Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)