### PR TITLE
Release 1.14.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased
+## 1.14.1
 
 ### Bugfixes
 


### PR DESCRIPTION
Promote the `unreleased` CHANGES section to 1.14.1.

Hotfix release: two production bugs found on v1.14.0 during a rolling deploy — the pool-slot leak on server-closed connections (#81, the serious one) and the spurious lz4 startup ERROR log (#82). See PR #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)