### PR TITLE
fix(instance): self-heal server-closed pooled connections to stop pool-slot leak

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## unreleased
+
+### Bugfixes
+
+- **Stop leaking pool slots when a pooled connection dies server-side** (#85).
+  When PostgreSQL closed a pooled connection while it was idle (a pooler/CNPG
+  idle-recycle, `idle_in_transaction_session_timeout`, or an operator),
+  `poll_invalidations()` raised on the first use.  During `Connection.open()`
+  ZODB does not guard that call, so it **stranded the connection** — its pool
+  slot was never returned.  Under sustained write load (a bulk
+  `reindexObject()` run) the pool filled with stranded slots until every
+  `getconn()` hit `PoolTimeout`; all pods went `0/1 Ready` with PostgreSQL
+  nearly idle, and only a restart recovered.  (The 1.14.1 `release()` fix,
+  #81, was already correct — this is a separate, open-path leak.)
+
+  Two changes make the read path self-heal instead of stranding:
+
+  - The instance pool now validates liveness on checkout
+    (`check=ConnectionPool.check_connection`), so `getconn()` never hands out
+    a connection that was closed while idle in the pool.
+  - `_begin_read_txn()` (run by `poll_invalidations`) now returns a
+    connection found broken and retries once on a fresh one, so a connection
+    that died while *held* by a reused ZODB connection is replaced rather than
+    raising through `Connection.open()`.
+
+  A write transaction whose connection is killed mid-flight still fails that
+  one transaction (a half-applied write cannot be resumed on a new
+  connection), but the pool now recovers and the pod stays healthy.
+
 ## 1.14.1
 
 ### Bugfixes

--- a/src/zodb_pgjsonb/instance.py
+++ b/src/zodb_pgjsonb/instance.py
@@ -31,6 +31,7 @@ from ZODB.utils import z64
 
 import logging
 import os
+import psycopg
 import shutil
 import tempfile
 import zodb_json_codec
@@ -177,13 +178,48 @@ class PGJsonbStorageInstance(ConflictResolvingStorage):
                 exc_info=True,
             )
 
+    def _replace_broken_conn(self):
+        """Return the current (broken) pooled connection and acquire a fresh one.
+
+        A pooled connection can be closed server-side while the instance holds
+        it (``idle_in_transaction_session_timeout``, an operator, or a
+        pooler/CNPG idle-recycle).  Returning the dead one lets the pool
+        discard and replace it; without this the slot would leak (#85).
+        """
+        old = self._conn
+        self._conn = None
+        self._in_read_txn = False
+        if old is not None:
+            try:
+                self._instance_pool.putconn(old)
+            except Exception:
+                logger.warning(
+                    "replacing broken connection: putconn failed", exc_info=True
+                )
+        self._conn = self._instance_pool.getconn()
+
     def _begin_read_txn(self):
         """Start a REPEATABLE READ snapshot transaction for consistent reads.
 
         All subsequent load()/loadBefore() queries will see a consistent
         point-in-time snapshot until _end_read_txn() is called.
+
+        ``poll_invalidations`` runs this at the start of every transaction and
+        during ``Connection.open()``.  If the pooled connection was closed
+        server-side, the ``BEGIN`` fails; we swap in a fresh connection and
+        retry once, so the read path self-heals instead of raising — which
+        would make ZODB strand the connection and leak its pool slot (#85).
         """
-        self._conn.execute("BEGIN ISOLATION LEVEL REPEATABLE READ")
+        try:
+            self._conn.execute("BEGIN ISOLATION LEVEL REPEATABLE READ")
+        except psycopg.OperationalError:
+            logger.warning(
+                "read snapshot BEGIN failed (connection closed server-side); "
+                "replacing connection and retrying",
+                exc_info=True,
+            )
+            self._replace_broken_conn()
+            self._conn.execute("BEGIN ISOLATION LEVEL REPEATABLE READ")
         self._in_read_txn = True
 
     def poll_invalidations(self):

--- a/src/zodb_pgjsonb/storage.py
+++ b/src/zodb_pgjsonb/storage.py
@@ -528,6 +528,13 @@ class PGJsonbStorage(CopyTransactionsMixin, ConflictResolvingStorage, BaseStorag
             timeout=pool_timeout,
             kwargs={"row_factory": dict_row},
             configure=_configure_pool_conn,
+            # Validate liveness on checkout: a pooled connection can be closed
+            # server-side while idle (idle_in_transaction_session_timeout, an
+            # operator, or a pooler/CNPG idle-recycle).  Without this, getconn
+            # hands out dead connections; the first use raises and — during
+            # Connection.open() — ZODB strands the connection, leaking its pool
+            # slot until the pool is exhausted (#85).
+            check=ConnectionPool.check_connection,
             open=True,
         )
         logger.debug("Connection pool ready")

--- a/tests/test_idle_in_xact.py
+++ b/tests/test_idle_in_xact.py
@@ -192,6 +192,117 @@ def test_release_returns_pool_slot_when_conn_killed_server_side():
         storage.close()
 
 
+def _kill_all_backends():
+    """Terminate every other backend on the test DB (mass server-side close)."""
+    killer = psycopg.connect(DSN)
+    try:
+        killer.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+        )
+        killer.commit()
+    finally:
+        killer.close()
+
+
+def test_poll_invalidations_reconnects_when_conn_killed():
+    """poll_invalidations must self-heal a server-closed pooled connection
+    instead of raising — a raise here makes ZODB strand the connection during
+    Connection.open() and leak its pool slot (#85)."""
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    clean_db()
+    storage = PGJsonbStorage(DSN, cache_warm_pct=0, pool_size=1, pool_max_size=3)
+    try:
+        instance = storage.new_instance()
+        try:
+            instance.poll_invalidations()
+            old_conn = instance._conn
+            _kill_backend(old_conn.info.backend_pid)
+
+            # Must not raise: the dead connection is replaced with a live one.
+            instance.poll_invalidations()
+
+            assert instance._conn is not old_conn
+            assert not instance._conn.closed
+            assert instance._in_read_txn is True
+        finally:
+            instance.release()
+    finally:
+        storage.close()
+
+
+def test_open_write_cycle_does_not_leak_pool_on_server_close():
+    """A write churn during which pooled connections are repeatedly closed
+    server-side must not permanently leak pool slots.  Without the fix, each
+    stranded Connection.open() leaks one slot until the pool hits max_size of
+    leaked slots and every getconn PoolTimeouts (#85).
+
+    Measures leaked slots directly: connections checked out of the pool whose
+    owning ZODB connection is gone.  It must stay ~baseline, not grow to
+    max_size.
+    """
+    from persistent.mapping import PersistentMapping
+    from zodb_pgjsonb.storage import PGJsonbStorage
+
+    import gc
+    import transaction as txn
+    import ZODB
+
+    clean_db()
+    storage = PGJsonbStorage(
+        DSN, cache_warm_pct=0, pool_size=2, pool_max_size=4, pool_timeout=3.0
+    )
+    pool = storage._instance_pool
+    checked_out = {}
+    _get, _put = pool.getconn, pool.putconn
+
+    def tracking_getconn(*a, **k):
+        conn = _get(*a, **k)
+        checked_out[id(conn)] = 1
+        return conn
+
+    def tracking_putconn(conn, *a, **k):
+        checked_out.pop(id(conn), None)
+        return _put(conn, *a, **k)
+
+    pool.getconn = tracking_getconn
+    pool.putconn = tracking_putconn
+
+    db = ZODB.DB(storage)
+
+    def cycle(i, kill=False):
+        if kill:
+            _kill_all_backends()
+        try:
+            conn = db.open()
+            try:
+                conn.root()[f"k{i}"] = PersistentMapping({"i": i})
+                txn.commit()
+            finally:
+                conn.close()
+        except Exception:
+            txn.abort()
+
+    try:
+        for i in range(3):
+            cycle(i)
+        gc.collect()
+        baseline = len(checked_out)
+
+        for i in range(3, 25):
+            cycle(i, kill=(i % 2 == 0))
+        gc.collect()
+        leaked = len(checked_out)
+
+        assert leaked <= baseline + 1, (
+            f"pool slots leaked: baseline={baseline} after_churn={leaked} (max_size=4)"
+        )
+    finally:
+        db.close()
+        storage.close()
+
+
 def test_zodb_connection_close_releases_virtualxid():
     """End-to-end: closing a read-only ZODB connection releases its virtualxid.
 


### PR DESCRIPTION
Fixes #85 — a production-down pool-slot leak observed on **1.14.1** during a multi-hour bulk `reindexObject()`: all 7 pods went `0/1 Ready` with PostgreSQL nearly idle, no self-recovery, only `kubectl rollout restart` fixed it.

## Root cause (not what the issue first suspected)

The `release()` fix in #81 (1.14.1) is already correct — `release()` always returns the connection. The leak is on a **different path**:

When PostgreSQL closes a pooled connection while it's idle (a pooler/CNPG idle-recycle, `idle_in_transaction_session_timeout`, or an operator), `poll_invalidations()` raises on the first use. ZODB's `DB.open()` calls `result.open()` → `poll_invalidations()` **unguarded** — so when it raises, ZODB strands the half-opened `Connection`; its pooled PG connection is never `release()`d. Each such event permanently leaks one slot. Under sustained writes the pool fills with leaked slots → every `getconn()` `PoolTimeout`s → pods wedged. PostgreSQL stays idle because the leaked connections are dead.

Verified with an instrumented end-to-end reproduction (getconn/putconn tracking): a write churn with repeated server-side closes leaks slots until the pool is exhausted (`4/4` on a `max_size=4` pool).

## Fix (both parts load-bearing — confirmed by isolation testing)

1. **Validate liveness on checkout** — `check=ConnectionPool.check_connection` on the instance pool, so `getconn()` never hands out a connection that was closed while idle in the pool.
2. **Reconnect on a broken held connection** — `_begin_read_txn()` (run by `poll_invalidations`) returns a connection found broken and retries once on a fresh one. `check` alone is insufficient: it only validates at checkout, not a connection that dies *while held* by a reused ZODB connection — that path still leaked `4/4` in testing. Reconnect alone is insufficient too: without `check`, the reconnect's `getconn()` just hands out another dead idle connection. Together they fix it (`leaked → baseline`).

A write transaction whose connection is killed mid-flight still fails that one transaction (a half-applied write can't be resumed on a new connection), but the pool now recovers and the pod stays healthy — no restart needed.

## Tests

`tests/test_idle_in_xact.py`:
- `test_open_write_cycle_does_not_leak_pool_on_server_close` — instrumented churn; asserts leaked slots stay at baseline (fails without fix: `baseline=1 after_churn=4`).
- `test_poll_invalidations_reconnects_when_conn_killed` — deterministic: after a server-side kill, `poll_invalidations()` self-heals to a fresh live connection instead of raising.

Both verified RED without the fix, GREEN with it. Full suite: **549 passed**; ruff clean.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)