### PR TITLE
Release 1.14.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased
+## 1.14.2
 
 ### Bugfixes
 


### PR DESCRIPTION
Promote the `unreleased` CHANGES section to 1.14.2.

Hotfix: pool-slot leak on server-closed pooled connections during sustained writes (#85, PR #86) — the open-path leak that wedged pods on 1.14.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)